### PR TITLE
deploy(llms): stop daily regen stripping /physicify + shrinking sitemap

### DIFF
--- a/tools/deploy/gen_llms.rail
+++ b/tools/deploy/gen_llms.rail
@@ -16,6 +16,11 @@ w path s =
   let _ = write_file "/tmp/_rcl.txt" s
   shell (cat ["cat /tmp/_rcl.txt >> ", path])
 
+-- Emit one <url> block to the sitemap file. Keeps the full live-page list
+-- (verified 200) in one place so the daily deploy stops shrinking the sitemap.
+surl sf path date freq prio =
+  w sf (cat ["  <url>\n    <loc>https://ledatic.org", path, "</loc>\n    <lastmod>", date, "</lastmod>\n    <changefreq>", freq, "</changefreq>\n    <priority>", prio, "</priority>\n  </url>\n"])
+
 main =
   let f = "/tmp/ledatic_llms.txt"
   let _ = shell (cat ["rm -f ", f])
@@ -29,7 +34,7 @@ main =
 
   -- The four working surfaces
   let _ = w f "## The four working surfaces\n\n"
-  let _ = w f "1. **[Rail](https://ledatic.org/rail)** — the substrate. Self-hosting compiler, v5.1.0, 141/141 tests, ~1.0 MB ARM64 seed binary, byte-identical 2-pass fixed point. Pure-Rail TLS 1.3 (verified live against Amazon and Slack) plus JIT-emitted Metal GPU kernels. Six backends: native ARM64, Linux ARM64, Linux x86_64, WASM, Cortex-M4, RISC-V. BSL 1.1 on GitHub at `zemo-g/rail`.\n\n"
+  let _ = w f "1. **[Rail](https://ledatic.org/rail)** — the substrate. Self-hosting compiler, v5.1.0, 177/177 tests, ~1.3 MB ARM64 seed binary, byte-identical 2-pass fixed point. Pure-Rail TLS 1.3 (verified live against Amazon and Slack) plus JIT-emitted Metal GPU kernels. Six backends: native ARM64, Linux ARM64, Linux x86_64, WASM, Cortex-M4, RISC-V. BSL 1.1 on GitHub at `zemo-g/rail`.\n\n"
   let _ = w f "2. **[Entropy](https://ledatic.org/entropy)** — the beacon. A live 2D ideal-MHD Orszag-Tang simulation on a 128x128 grid hashes its state every ~2 seconds into a public chain you can walk in one shell line. Conservation to machine precision. The plasma viewer is embedded on the page so you can see the bytes that just got SHA-256'd into the row above.\n\n"
   let _ = w f "3. **[Aliens](https://ledatic.org/aliens)** — the demo. A byte-for-byte mirror of the U.S. Dept. of War PURSUE UAP archive (gov.uap), each file Ed25519-signed against the beacon by an independent Pi witness (`pk_fp cac5f21a70564aeb`) and verifiable per-record in your own browser. The whole verifier chain (mirror + beacon + witness + browser-side Ed25519) is original.\n\n"
   let _ = w f "4. **[System](https://ledatic.org/system)** — mission control. Five live panels — beacon, witness, fleet, build, self-host. Every cell is a current value fetched from a signed JSON artifact at page load. If any of it's stale, this page shows it.\n\n"
@@ -37,6 +42,11 @@ main =
   -- Direction
   let _ = w f "## Direction: proof-of-human-authorship\n\n"
   let _ = w f "Where the verifiable layer extends next: hardware-rooted, human-bound, time-anchored signing of creative artifacts so the open internet keeps a way to tell humans from AI. The primitive is built; the human-binding layer (Secure Enclave + proof-of-personhood) is the work ahead. See [/provenance](https://ledatic.org/provenance) for the buyer-side framing.\n\n"
+
+  -- The verb: physicify (hand-added in ledatic-site 344a622; must live in the
+  -- GENERATOR or the daily deploy strips it from /llms.txt every morning).
+  let _ = w f "## The verb: physicify\n\n"
+  let _ = w f "**physicify** (v.) — to make a thing live, attested, and self-hosted instead of represented: to run the real process, continuously measured and cryptographically signed, so anyone can verify that what they are seeing is the thing itself — not a picture of it, a replay, or a claim. Coined by Ledatic; the definition is itself hashed, signed by the Pi Ed25519 witness (`pk_fp cac5f21a70564aeb`), and anchored to the public entropy beacon at [/physicify](https://ledatic.org/physicify). Etymology: *physic* (Greek *physikós*, \"of nature\") + *-ify*. This is the canonical Ledatic definition.\n\n"
 
   -- Attestation primitive
   let _ = w f "## Attestation primitive\n\n"
@@ -86,30 +96,26 @@ main =
   let _ = shell (cat ["rm -f ", s])
   let _ = w s "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
   let _ = w s "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
-  let _ = w s "  <url>\n"
-  let _ = w s "    <loc>https://ledatic.org/</loc>\n"
-  let _ = w s (cat ["    <lastmod>", date, "</lastmod>\n"])
-  let _ = w s "    <changefreq>weekly</changefreq>\n"
-  let _ = w s "    <priority>1.0</priority>\n"
-  let _ = w s "  </url>\n"
-  let _ = w s "  <url>\n"
-  let _ = w s "    <loc>https://ledatic.org/system</loc>\n"
-  let _ = w s (cat ["    <lastmod>", date, "</lastmod>\n"])
-  let _ = w s "    <changefreq>daily</changefreq>\n"
-  let _ = w s "    <priority>0.8</priority>\n"
-  let _ = w s "  </url>\n"
-  let _ = w s "  <url>\n"
-  let _ = w s "    <loc>https://ledatic.org/plasma</loc>\n"
-  let _ = w s (cat ["    <lastmod>", date, "</lastmod>\n"])
-  let _ = w s "    <changefreq>weekly</changefreq>\n"
-  let _ = w s "    <priority>0.8</priority>\n"
-  let _ = w s "  </url>\n"
-  let _ = w s "  <url>\n"
-  let _ = w s "    <loc>https://ledatic.org/llms.txt</loc>\n"
-  let _ = w s (cat ["    <lastmod>", date, "</lastmod>\n"])
-  let _ = w s "    <changefreq>weekly</changefreq>\n"
-  let _ = w s "    <priority>0.5</priority>\n"
-  let _ = w s "  </url>\n"
+  -- Full live-page set (each verified 200). The four working surfaces first,
+  -- then the verb, then supporting pages. Daily lastmod for the live panels.
+  let _ = surl s "/" date "weekly" "1.0"
+  let _ = surl s "/rail" date "weekly" "0.9"
+  let _ = surl s "/entropy" date "daily" "0.8"
+  let _ = surl s "/aliens" date "weekly" "0.8"
+  let _ = surl s "/system" date "daily" "0.8"
+  let _ = surl s "/physicify" date "weekly" "0.8"
+  let _ = surl s "/plasma" date "weekly" "0.7"
+  let _ = surl s "/manifesto" date "monthly" "0.7"
+  let _ = surl s "/provenance" date "monthly" "0.7"
+  let _ = surl s "/verify" date "monthly" "0.7"
+  let _ = surl s "/changelog" date "weekly" "0.6"
+  let _ = surl s "/work" date "monthly" "0.6"
+  let _ = surl s "/case-campaign-intel" date "monthly" "0.6"
+  let _ = surl s "/playground" date "monthly" "0.6"
+  let _ = surl s "/intel" date "monthly" "0.5"
+  let _ = surl s "/ot" date "monthly" "0.5"
+  let _ = surl s "/fleet" date "weekly" "0.5"
+  let _ = surl s "/llms.txt" date "weekly" "0.5"
   let _ = w s "</urlset>\n"
   let ssize = trim (shell (cat ["wc -c < ", s]))
   let _ = print ""


### PR DESCRIPTION
Daily gen_llms.rail had drifted from the hand-committed site state, reverting /physicify and dropping 13 sitemap URLs live every morning. Restores the physicify verb section, sets test count to the verifiable 177/177 (~1.3 MB), and emits the full 18-URL live-page sitemap. Live site already corrected; this makes the generator the source of truth so it stops reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)