### PR TITLE
fix(attest): parse signer_url into host/port/path

### DIFF
--- a/tools/attest/attest.rail
+++ b/tools/attest/attest.rail
@@ -223,12 +223,35 @@ now_unix _ =
 
 -- ── Main ─────────────────────────────────────────────────────────────
 
+-- Parse "http://HOST:PORT/PATH" (or "HOST:PORT/PATH" / "HOST:PORT" / "HOST")
+-- into (host, port_string, path). The ~/.ledatic/witness/signer_url file holds a
+-- full URL; the old code read it straight into signer_ip, so hc_connect_tcp got
+-- "http://...:9102/sign" as a hostname and failed ("witness signer returned
+-- nothing"). This parses it, and is robust to a bare IP too; missing parts fall
+-- back to the 9102 / /sign defaults. SIGNER_IP/PORT/PATH env still override.
+strip_scheme s =
+  let i = str_find "://" s
+  if i < 0 then s else str_sub s (i + 3) (length (chars s) - i - 3)
+
+parse_signer_url raw =
+  let s = strip_scheme (trim_trailing raw)
+  let slash = str_find "/" s
+  let authority = if slash < 0 then s else str_sub s 0 slash
+  let path = if slash < 0 then (signer_path_default 0) else str_sub s slash (length (chars s) - slash)
+  let colon = str_find ":" authority
+  let host = if colon < 0 then authority else str_sub authority 0 colon
+  let port_s = if colon < 0 then show (signer_port_default 0) else str_sub authority (colon + 1) (length (chars authority) - colon - 1)
+  (host, port_s, path)
+
 attest input out =
   let beacon_url = env_or "BEACON_URL" (beacon_url_default 0)
-  let signer_ip = env_or "SIGNER_IP" (trim_trailing (read_file (signer_url_path_default 0)))
-  let signer_port_s = env_or "SIGNER_PORT" (show (signer_port_default 0))
+  let signer_url_raw = env_or "SIGNER_URL" (trim_trailing (read_file (signer_url_path_default 0)))
+  let parsed = parse_signer_url signer_url_raw
+  let (purl_host, purl_port, purl_path) = parsed
+  let signer_ip = env_or "SIGNER_IP" purl_host
+  let signer_port_s = env_or "SIGNER_PORT" purl_port
   let signer_port = parse_int signer_port_s
-  let signer_path = env_or "SIGNER_PATH" (signer_path_default 0)
+  let signer_path = env_or "SIGNER_PATH" purl_path
   let token_path = env_or "SIGN_TOKEN_PATH" (sign_token_path_default 0)
   let token = trim_trailing (read_file token_path)
   if length (chars token) == 0 then


### PR DESCRIPTION
## What

`attest.rail` read `~/.ledatic/witness/signer_url` (a full URL like `http://HOST:9102/sign`) straight into `signer_ip`, so `hc_connect_tcp` got the entire URL as a hostname, the connection failed, and the tool printed `witness signer returned nothing` — while the Pi signer at `:9102/sign` was healthy the whole time.

## Fix

Parse the signer URL into `(host, port, path)`: strip the scheme, split authority/path on the first `/`, split `host:port` on `:`. Robust to a bare IP (no scheme/port → falls back to the 9102 / `/sign` defaults). `SIGNER_IP` / `SIGNER_PORT` / `SIGNER_PATH` env overrides still take precedence.

## Verified

Signs a file and `verify.sh` returns `ok` (pk_fp `cac5f21a70564aeb`) **without** the `SIGNER_IP=` workaround. Surfaced while Pi-signing the Lakes RLAR attestation artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
