### PR TITLE
docs: reconcile getting-started/README/builtins with v5.2.0 reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ---
 
-Rail compiles itself. The compiler — ~6,000+ lines of Rail — produces a ~1.0 MB ARM64 binary that compiles the compiler again and reaches a byte-identical fixed point in 2 cycles. There is no C in the runtime, no libc in the binary. The garbage collector is ARM64 assembly. The TLS 1.3 client is also Rail: `import "stdlib/anthropic_client.rail"` and your program talks HTTPS to `api.anthropic.com` with zero OpenSSL, zero curl, zero socat. As of **v5.2.0**, the toolchain stands entirely alone: Rail assembles, links, and code-signs its own Mach-O binaries in-process — no `as`, no `ld`, no `codesign` — so the self-compile is bit-reproducible (the committed seed reproduces itself byte-for-byte). It also emits its own aarch64 Linux ELF binaries and its own GPU kernels, generating Metal Shading Language from an op-DAG and JIT-compiling it at runtime (35× fused rmsnorm+QKV, 18× fused silu+hadamard). A frontier model + 1 KB Rail spec still compiles 30/30 on a held-out hard-bench — publicly reproducible.
+Rail compiles itself. The compiler — ~9,200 lines of Rail — produces a ~0.9 MB ARM64 binary that compiles the compiler again and reaches a byte-identical fixed point in 2 cycles. There is no C in the runtime, no libc in the binary. The garbage collector is ARM64 assembly. The TLS 1.3 client is also Rail: `import "stdlib/anthropic_client.rail"` and your program talks HTTPS to `api.anthropic.com` with zero OpenSSL, zero curl, zero socat. As of **v5.2.0**, the toolchain stands entirely alone: Rail assembles, links, and code-signs its own Mach-O binaries in-process — no `as`, no `ld`, no `codesign` — so the self-compile is bit-reproducible (the committed seed reproduces itself byte-for-byte). It also emits its own aarch64 Linux ELF binaries and its own GPU kernels, generating Metal Shading Language from an op-DAG and JIT-compiling it at runtime (35× fused rmsnorm+QKV, 18× fused silu+hadamard). A frontier model + 1 KB Rail spec still compiles 30/30 on a held-out hard-bench — publicly reproducible.
 
 ```
 ./rail_native self && cp /tmp/rail_self ./rail_native  # cycle 1
@@ -50,7 +50,7 @@ Apple Silicon (ARM64 macOS) is the primary target; Linux ARM64, Linux x86_64, We
 ```bash
 ./rail_native <file.rail>        # compile to /tmp/rail_out
 ./rail_native run <file.rail>    # compile + execute
-./rail_native test               # run the 140-test suite
+./rail_native test               # run the 178-test suite
 ./rail_native self               # self-compile, fixed point at gen2
 ./rail_native x86 <file.rail>    # cross-compile to Linux x86_64
 ./rail_native linux <file.rail>  # cross-compile to Linux ARM64
@@ -64,7 +64,7 @@ Apple Silicon (ARM64 macOS) is the primary target; Linux ARM64, Linux x86_64, We
 ### 1. Compiles itself, byte-identical
 
 ```
-./rail_native self                    -- ~7,050 lines of Rail →
+./rail_native self                    -- ~9,200 lines of Rail →
                                       --   a ~1.0 MB ARM64 binary
 cp /tmp/rail_self ./rail_native       -- cycle 1: install gen1
 ./rail_native self                    -- cycle 2: that binary compiles

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -84,7 +84,7 @@ head [10, 20, 30]    -- returns 10
 head ["a", "b"]      -- returns "a"
 ```
 
-Calling `head` on an empty list is undefined behavior.
+Calling `head` on an empty list returns `0`. (Rail runtime safety: both `head []` and `head` on a non-list return `0` rather than segfaulting.)
 
 ### `tail`
 
@@ -93,6 +93,7 @@ Return all elements except the first.
 ```rail
 tail [10, 20, 30]    -- returns [20, 30]
 tail [1]             -- returns []
+tail []              -- returns [] (tail on a non-list also returns [])
 ```
 
 ### `cons`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,13 +1,12 @@
 # Getting Started with Rail
 
-Rail is a self-hosting programming language that compiles to native ARM64 binaries. The compiler is written in Rail itself (1,979 lines) and produces byte-identical output when compiling itself -- a fixed point.
+Rail is a self-hosting programming language that compiles to native ARM64 binaries. The compiler is written in Rail itself (~9,200 lines) and produces byte-identical output when compiling itself -- a fixed point.
 
 ## Requirements
 
 - Apple Silicon Mac (ARM64 macOS)
-- macOS assembler (`as`) and linker (`ld`) -- included with Xcode Command Line Tools
 
-No other dependencies. No package manager. No runtime.
+That's the whole list. As of v5.2.0, Rail assembles, links, and code-signs its own binaries in-process -- no `as`, no `ld`, no `codesign`, no Xcode toolchain. No package manager. No runtime. No C.
 
 ## Install
 
@@ -16,7 +15,7 @@ git clone https://github.com/zemo-g/rail
 cd rail
 ```
 
-That's it. The seed binary (`rail_native`, ~367K) is checked into the repo.
+That's it. The seed binary (`rail_native`, ~870K) is checked into the repo.
 
 ## Hello World
 
@@ -55,9 +54,8 @@ When you run `./rail_native hello.rail`, the compiler:
 2. Parses tokens into an AST
 3. Checks exhaustiveness of pattern matches (warnings, not errors)
 4. Generates ARM64 assembly
-5. Calls `as` to assemble into an object file
-6. Calls `ld` to link with the C runtime (`runtime/gc.c`, `runtime/llm.c`) into a Mach-O binary
-7. Writes the binary to `/tmp/rail_out`
+5. Assembles, links, and ad-hoc code-signs it into a Mach-O binary -- **in-process, in pure Rail** (no `as`, `ld`, `codesign`, or C runtime)
+6. Writes the binary to `/tmp/rail_out`
 
 With `run`, it then executes `/tmp/rail_out`.
 
@@ -96,7 +94,7 @@ Key things to note:
 ./rail_native test
 ```
 
-This runs 70 built-in tests covering integers, strings, lists, tuples, ADTs, closures, FFI, concurrency, and more. All 70 should pass.
+This runs 178 built-in tests covering integers, strings, lists, tuples, ADTs, closures, FFI, concurrency, and more. All 178 should pass.
 
 ## Self-Compilation
 
@@ -128,7 +126,7 @@ diff /tmp/rail_self /tmp/rail_out
 # Step 5: If not identical, repeat steps 2-4 until stable
 
 # Step 6: Run tests
-./rail_native test    # should be 70/70
+./rail_native test    # should be 178/178
 ```
 
 ## Other Commands
@@ -145,13 +143,10 @@ diff /tmp/rail_self /tmp/rail_out
 
 ```
 rail/
-  rail_native           # seed binary (ARM64, ~367K)
+  rail_native           # seed binary (ARM64, ~870K)
   tools/
-    compile.rail        # the compiler (~1,979 lines of Rail)
-  runtime/
-    gc.c                # garbage collector (conservative mark-sweep)
-    llm.c               # LLM builtin implementation
-  stdlib/               # 22 standard library modules
+    compile.rail        # the compiler (~9,200 lines of Rail; GC + runtime are ARM64 asm inside it)
+  stdlib/               # 101 standard library modules
   examples/             # example programs
   docs/                 # documentation (you are here)
 ```
@@ -160,5 +155,5 @@ rail/
 
 - [Language Reference](language-reference.md) -- complete syntax guide
 - [Builtins](builtins.md) -- every built-in function
-- [Standard Library](stdlib.md) -- all 22 stdlib modules
+- [Standard Library](stdlib.md) -- all 101 stdlib modules
 - [Examples](examples.md) -- annotated example programs


### PR DESCRIPTION
## What

Reconciles the public docs with the actual v5.2.0 tree. An external review
(Sakana `fugu-ultra` pouring over the language) surfaced that several
"check me" surfaces contradict each other and the release's own headline.
Every fix was verified against the working tree, not taken on the
reviewer's word.

## Changes

- **docs/getting-started.md** — drops the stale `as`/`ld` + C-runtime
  (`runtime/gc.c`/`runtime/llm.c`) build path that directly contradicted the
  v5.2.0 "stands alone — no as/ld/codesign" claim; those `runtime/*.c` files
  are not even tracked. Numbers: compiler 1,979→~9,200 LOC, tests 70→178,
  stdlib 22→101, seed ~367K→~870K.
- **README.md** — current-state compiler size `~6,000+`/`~7,050`→`~9,200`;
  `140-test suite`→`178-test suite` (was inconsistent with its own `178/178`
  badge). Release-history numbers (v3.0.0/v4.0.0) left as-is.
- **docs/builtins.md** — `head []` "undefined behavior"→returns `0`;
  documents `tail []`→`[]`, matching the runtime-safety guarantees.

## Verification (origin/master @ d742205)

| Claim | Was | Now (verified) |
|---|---|---|
| compile.rail LOC | 1,979 / 6,000+ / 7,050 | 9,198 |
| test count | 70 / 140 | 178 |
| stdlib modules | 22 | 101 |
| seed binary | ~367K | 891,944 B |
| tracked `runtime/*.c` | implied (gc.c/llm.c) | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmHLhbmQMwFjkzC5WLiu3Z
