### PR TITLE
perf(jit): array-backed op-DAG tape - O(n^2) -> O(n) build

### DIFF
--- a/stdlib/jit_match.rail
+++ b/stdlib/jit_match.rail
@@ -94,7 +94,7 @@ walk_tape_loop tape i n acc =
     walk_tape_loop tape (i + 1) n new_acc
 
 walk_tape tape =
-  let n = length tape
+  let n = jit_tape_len tape
   walk_tape_loop tape 0 n []
 
 -- ───────────────────────────────────────────────────────────────────────

--- a/stdlib/jit_node.rail
+++ b/stdlib/jit_node.rail
@@ -25,19 +25,43 @@ type TracedTensor = | Traced value tape_idx
 -- TAPE MANAGEMENT
 -- ───────────────────────────────────────────────────────────────────────
 
-jit_tape_new _ = []
+-- Array-backed op-DAG tape: slot 0 holds the node count, slots 1..count hold
+-- JitNodes. Push is O(1) amortized (doubling) and get is O(1); the old list
+-- form did `length` + `append` per push (O(n^2) build) and an O(i) walk per get.
+jit_tape_new _ =
+  let a = arr_new 64 0
+  let _ = arr_set a 0 0
+  a
 
+-- jit_tape_len: number of nodes on the tape (O(1)).
+jit_tape_len tape = arr_get tape 0
+
+-- jit_tape_push: store node at slot count+1 (growing if full), return [tape, idx].
 jit_tape_push tape node =
-  let idx = length tape
-  let new_tape = append tape (cons node [])
-  cons new_tape (cons idx [])
+  let n = arr_get tape 0
+  let cap = arr_len tape
+  let t = if n + 1 < cap then tape else jit_tape_grow tape
+  let _ = arr_set t (n + 1) node
+  let _ = arr_set t 0 (n + 1)
+  cons t (cons n [])
 
-jit_tape_get tape i = jit_tape_get_acc tape i 0
+jit_tape_grow tape =
+  let big = arr_new (arr_len tape * 2) 0
+  let _ = jit_tape_copy tape big (arr_get tape 0)
+  big
 
-jit_tape_get_acc tape i cur =
-  if cur > i then JitNode "missing" [] "f64" []
-  else if cur == i then head tape
-  else jit_tape_get_acc (tail tape) i (cur + 1)
+jit_tape_copy src dst k =
+  if k < 0 then 0
+  else
+    let _ = arr_set dst k (arr_get src k)
+    jit_tape_copy src dst (k - 1)
+
+-- jit_tape_get: O(1) random access; slot 0 is the count, node i lives at slot i+1.
+-- Out-of-range (i<0 or i>=count) returns the "missing" sentinel, as before.
+jit_tape_get tape i =
+  if i < 0 then JitNode "missing" [] "f64" []
+  else if i >= arr_get tape 0 then JitNode "missing" [] "f64" []
+  else arr_get tape (i + 1)
 
 -- ───────────────────────────────────────────────────────────────────────
 -- UTILITIES
@@ -82,6 +106,6 @@ jit_tape_dump_loop tape n i =
     jit_tape_dump_loop tape n (i + 1)
 
 jit_tape_dump tape =
-  let n = length tape
+  let n = jit_tape_len tape
   let _ = print (cat ["=== jit tape (", show n, " nodes) ==="])
   jit_tape_dump_loop tape n 0

--- a/tools/test/jit_tape_smoke.rail
+++ b/tools/test/jit_tape_smoke.rail
@@ -90,7 +90,7 @@ main =
   -- Verify DAG structure.
   let _ = jit_tape_dump tapeF
 
-  let n = length tapeF
+  let n = jit_tape_len tapeF
   let _ = print (cat ["\nexpected n=9 (5 leaves + 1 rmsnorm + 3 matmul)  got n=", show n])
   let _ = if n == 9 then print "PHASE 1.0 SCAFFOLD — GREEN" else print "FAIL"
   0


### PR DESCRIPTION
## What

Makes the JIT op-DAG tape (`stdlib/jit_node.rail`) array-backed so building it
is O(n) instead of O(n²) — the same footgun fixed for the autograd tape in #27.

## The bug

`jit_tape_push` ran `length tape` **and** `append tape …` (both O(n)) on every
push, so building an n-node DAG was **O(n²)**. (Its `get` was already O(i), no
per-step `length`.)

## The fix

Array-backed log: slot 0 = node count, slots 1..count = `JitNode`s, doubling
growth. Push is O(1) amortized, get is O(1), and out-of-range still returns the
`"missing"` `JitNode` sentinel. The `[tape, idx]` return shape is unchanged, so
`jit_emit` / `jit_tape` are untouched — only the two consumers that read
`length tape` directly (`jit_match` `walk_tape`, `jit_tape_smoke`) move to
`jit_tape_len`.

Lower-impact than the autograd fix (DAGs are small), landed for consistency so
the footgun class is closed.

## Verification (all green)

| Test | Result |
|---|---|
| `jit_tape_smoke` | n=9 GREEN |
| `jit_dag_match_smoke` | 2 fusions, correct indices |
| `jit_emit_smoke` | GREEN |
| `jit_emit_shaped_smoke` | GREEN |
| `jit_emit_fuzz` | 1000/1000 over 200 shapes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmHLhbmQMwFjkzC5WLiu3Z
