### PR TITLE
docs: grounding contracts (numerics, attested subset, threat model)

### DIFF
--- a/docs/INDEPENDENCE.md
+++ b/docs/INDEPENDENCE.md
@@ -1,0 +1,74 @@
+# Independent verification: closing the trusting-trust gap
+
+[THREAT_MODEL.md](THREAT_MODEL.md) names the one gap Rail's self-hosting does not
+close: **a Rail compiler verifying a Rail compiler is not independent.** A
+byte-identical self-compile proves a fixed point exists; it does not prove the seed
+binary faithfully implements its source. A malicious seed could reproduce itself
+byte-for-byte while miscompiling a target (Thompson's "trusting trust"). This is the
+design for an *independent* check. It is a plan, not yet a guarantee.
+
+## The threat, precisely
+
+A trojaned `rail_native` that (a) miscompiles some program P and (b) re-inserts (a)
+when it compiles `compile.rail`. Reproducible builds do not catch this — the trojan
+reproduces itself. The source is auditable, so a *source* trojan is out of scope;
+the danger is a **binary** behaviour absent from the source.
+
+## Options, by how much independence they actually buy
+
+### Option A — Non-Rail reference interpreter + differential testing  ★ recommended first
+Implement a small interpreter for a **frozen Rail-core subset** in a *different
+language* (e.g. Python), covering the constructs the test + conformance corpora use
+(ints, lists, tuples, ADTs, pattern match, closures, the core builtins). Run every
+corpus program through **both** `rail_native` (compile → run) and the independent
+interpreter, and diff the outputs.
+
+- **Independence: genuine** (different language, different author-path). A trojaned
+  seed that miscompiles a covered program P diverges from the interpreter → detected.
+- **Coverage: partial** — whatever the interpreter + corpus exercise. Grows over time.
+- **Cost: low**, and it reuses the existing 178-test + `tools/test/conformance/` corpus.
+- **Note:** this is the one component that *must not* be Rail — independence requires
+  a non-Rail implementation. It is a deliberate, justified exception to the
+  Rail-on-Rail convention, not a violation.
+
+### Option B — Diverse Double-Compilation via the x86_64 backend
+Cross-compile `compile.rail` with the x86_64 backend → `M_x86`; run `M_x86` to
+compile `compile.rail` back to ARM64 → `O`; compare `O` to the normal ARM64
+self-compile.
+
+- **Independence: weak for this threat.** `M_x86` is produced *by the same ARM64
+  seed*, so a seed-resident trojan is inherited. This checks **ARM64-vs-x86 codegen
+  agreement** (genuinely useful for *correctness* / differential miscompilation), but
+  does **not** defeat a trojan living in the seed.
+- **Cost: low** — reuses the existing x86_64 backend. Good as a complementary
+  cross-backend consistency check, not as the trusting-trust answer.
+
+### Option C — Independently-bootstrapped second seed
+A minimal bootstrap chain from a tiny, hand-auditable core (à la bootstrappable.org /
+GNU Mes / Wheeler's DDC with a genuinely different compiler).
+
+- **Independence: strongest.** Also the most work; long-term goal.
+
+## Recommended phased plan
+
+1. **Phase 3a (Option A)** — the non-Rail reference interpreter + differential run over
+   the corpus. Genuine independence, tractable, reuses the conformance suite.
+2. **Phase 3b (Option B)** — wire the x86 cross-compile diff as a complementary
+   cross-backend consistency check in CI.
+3. **Phase 3c (Option C)** — a minimal independently-bootstrapped core, when warranted.
+
+## What to claim (and not) once 3a exists
+
+> Every corpus program produces identical output under `rail_native` and an
+> independent non-Rail interpreter — so a seed trojan affecting any covered program
+> would have to also corrupt the independent checker, which it cannot reach.
+
+Not "the compiler is proven correct." Coverage is the corpus; the claim is bounded by
+it, and [STATUS.md](STATUS.md) / [VERIFY.md](../VERIFY.md) should state that bound.
+
+## Decision needed before the prototype (Phase 3b/3c-independent #11)
+
+The reference interpreter introduces **non-Rail code** into the repo for the first
+time on purpose. That is the right call for an independence checker, but it deviates
+from the Rail-on-Rail convention and should be an explicit, owned decision — hence
+the prototype is gated.

--- a/docs/NUMERICS.md
+++ b/docs/NUMERICS.md
@@ -1,0 +1,60 @@
+# Rail numerics contract
+
+What is bit-exact and reproducible in Rail, what is not, and where the boundary
+is. This exists because "bit-exact" is only a checkable claim if the numeric
+contract is written down. Scope it to a platform; do not assume cross-platform
+bit-identity for the float/libm/GPU paths.
+
+## Exact & deterministic: integer and fixed-point
+
+- **63-bit tagged integers** are exact. Arithmetic (`+ - * / %`) is integer-exact;
+  there is no silent float promotion unless a float operand is present.
+- **`mul_shr a b s`** computes `(a*b) >> s` in a **full 128-bit intermediate**
+  (`mul` low-64 + `smulh` high-64; `tools/compile.rail`), so fixed-point multiply
+  does not overflow the 63-bit tag. This is the overflow-safe primitive behind
+  Rail's bit-exact ML: the SmolLM2-135M and Qwen3 forward passes that reproduce
+  HuggingFace **bit-for-bit** run an **integer-exact** path (see
+  `tools/bitexact/`), not floating point.
+- **`idot`** is an exact integer dot-product / matmul used on that path.
+- The integer path is bit-identical on any conforming ARM64. **This is the
+  substrate the attestation claims rest on** — integers, not floats.
+
+Overflow is a real hazard on the 63-bit tag; guard multiplicative/loop code with
+`mul_shr` or two-limb arithmetic. See `tools/bitexact/` for the overflow tests.
+
+## Deterministic per-platform: IEEE 754 doubles
+
+- Floats are **unboxed IEEE 754 doubles in ARM64 d-registers**. `fadd`/`fmul`/
+  `fdiv`/`fsqrt` are round-to-nearest-even and deterministic **on a given ISA**.
+- **Reduction order is fixed by the source** — Rail does not reassociate or
+  auto-vectorize float reductions, so `fold (+) 0.0 xs` sums left-to-right every
+  time.
+- **Precision regime:** bf16 (f32 exponent range, no fp16 NaN cliff) for
+  activations; **f64 on the embedding and LM-head** — the "f64 truth line".
+
+## NOT bit-identical across platforms (the escape hatches)
+
+These compile and run, but break cross-platform bit-identity. Bit-exact work must
+avoid them or pin the platform. See [SAFE_SUBSET.md](SAFE_SUBSET.md).
+
+- **Host libm via FFI** — `sin cos sqrt pow exp log tanh` (`stdlib/math.rail`) call
+  the platform's libm, which is **not correctly-rounded** and differs across OS /
+  libm versions. A bit-exact path uses integer/polynomial approximations instead.
+- **GPU / Metal** — FMA contraction, reduction order, and denormal handling differ
+  from the CPU path; GPU bit-exactness requires the integer-exact path or
+  tightly-pinned kernels, not the default.
+- **x86_64 backend** — float lowering/rounding may differ from ARM64.
+
+## What "bit-exact" is scoped to
+
+A **specific platform** (ARM64 macOS), a **specific attested build** (the committed
+seed, sha in [STATUS.md](STATUS.md)), and the **integer-exact path**. Cross-platform
+bit-identity is **not** claimed for float, libm, or GPU paths.
+
+## How to verify
+
+- `tools/bitexact/` — the integer-exact forward/train harness + overflow guards.
+- The HF-parity demos: SmolLM2 reproduced to a pinned sha; Qwen3 first-logit
+  `g[0]=12095` matches HF greedy. These are reproducible, not asserted.
+- Provenance, not correctness: a bit-identical result proves *the same computation
+  ran*, not that the computation is *right*. See [THREAT_MODEL.md](THREAT_MODEL.md).

--- a/docs/SAFE_SUBSET.md
+++ b/docs/SAFE_SUBSET.md
@@ -1,0 +1,47 @@
+# Rail attested subset
+
+A *verifiable* / *replayable* computation must be hermetic and deterministic: the
+same inputs must produce the same bytes, with nothing reaching outside the
+sandbox. Rail's full language is deliberately larger than that — it has FFI, a
+shell, raw pointers, and compile-time codegen. This page draws the line.
+
+## Inside the attested subset (hermetic, deterministic)
+
+- Pure Rail: functions, ADTs, pattern matching, closures, lists, tuples, strings.
+- Integer / fixed-point arithmetic (exact; see [NUMERICS.md](NUMERICS.md)).
+- IEEE 754 doubles **within one platform** (deterministic, fixed reduction order).
+- GC-managed memory (`cons`, `arr_new`/`arr_get`/`arr_set`, the bump arena +
+  conservative GC).
+- File reads of pinned inputs, deterministic string ops.
+
+Code in this subset is reproducible: re-running it on the same platform yields
+byte-identical results, which is what attestation signs over.
+
+## Outside the attested subset
+
+These compile and are useful, but they break hermeticity or determinism. A program
+that uses them **cannot** be treated as a reproducible/attested computation without
+additional pinning, and a result derived through them is not covered by the
+reproducibility claim.
+
+| Construct | Why it's outside |
+|---|---|
+| `foreign` (FFI) | Calls host code; results depend on the host library/version. Can return raw pointers that bypass Rail's object model. |
+| `shell` | Runs arbitrary host commands — fully non-hermetic and non-deterministic. |
+| raw pointer returns (`-> ptr` / `-> str`) | Escape Rail's GC'd value model; lifetime/aliasing are unchecked. |
+| `arena_reset` | Manually invalidates allocations after a mark; misuse creates dangling references. |
+| `rc_alloc` / `rc_retain` / `rc_release` | Manual reference counting outside the GC; correctness is the caller's burden. |
+| `#generate` / compile-time LLM codegen | Non-deterministic and non-hermetic; splices model-generated code at build time. |
+| host **libm** (`sin`/`cos`/`sqrt`/…) | Not correctly-rounded; not bit-identical across platforms ([NUMERICS.md](NUMERICS.md)). |
+| Metal / GPU JIT | Kernel determinism (FMA, reduction order, denormals) is not guaranteed by default. |
+
+## Rule of thumb
+
+If a computation is meant to be **attested or independently reproduced**, keep it
+inside the subset and pin its inputs. If it must step outside (e.g. GPU training, an
+HTTPS fetch), the hermetic boundary moves to the *artifact* it produces — pin and
+sign that artifact, and treat the non-hermetic step as trusted input, not as part of
+the verified computation.
+
+A future `tools/lint/check_quirks.rail` pass can flag out-of-subset constructs in
+code annotated as attested; today the boundary is enforced by convention and review.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,71 @@
+# Rail attestation threat model
+
+Rail's motto is **"check me, don't trust me."** That is only meaningful if it says
+*who could lie, what it would cost them, and what is out of scope.* This page makes
+the claim falsifiable. The claim is **never** "proof of truth."
+
+## What is signed
+
+- **Release artifacts** — the committed seed binary and self-host artifacts
+  (`tools/attest/attest_release.sh`, `release_index.rail`).
+- **Self-host attestations** — that the seed reproduces itself byte-identically
+  (`attest_selfhost.sh`).
+- **Test-run attestations** — that the suite passed at a given revision
+  (`attest_test_run.sh`).
+- **(ML) per-step gradient ledgers** — on the attested-training path, each step's
+  inputs/outputs are hashed and signed, so a forged gradient fails verification.
+
+Signatures are **Ed25519**. Each attestation is anchored to a **public entropy
+beacon** (`ledatic.org/entropy`) by `pulse_id`, giving tamper-evident sequencing
+that no single party controls.
+
+## Who signs, and the verifiers
+
+- A **witness signer** holds the Ed25519 private key and signs attestations
+  (`tools/attest/pi_sign_server.rail`).
+- **`tools/attest/verify.rail`** re-checks signatures and hashes — the verifier is
+  itself Rail.
+- A **reproducibility witness** rebuilds public master from source daily and
+  `cmp`s the committed seed (`com.ledatic.rail_repro_witness`), alerting on
+  mismatch.
+- **Anyone** can run `./verify_reproducible.sh` (see [VERIFY.md](../VERIFY.md)) to
+  reproduce the seed from source on their own machine — the strongest check,
+  because it does not require trusting the maintainer.
+
+## What an undetected lie costs
+
+> An undetected lie costs the compromise or collusion of **every independent
+> verifier that actually recomputes the relevant artifact from pinned inputs under
+> this contract.**
+
+It does **not** cost "a conspiracy" in the abstract — it costs exactly the
+load-bearing elements below. Naming them is the point.
+
+### Load-bearing assumptions (compromise any one and the guarantee weakens)
+
+- The **signer key** is not exfiltrated.
+- The **build is reproducible** from pinned source + compiler + environment.
+- The **verifier** (`verify.rail`, `verify_reproducible.sh`) is itself correct.
+- At least one **independent** verifier recomputes — see the gap below.
+- The pinned inputs (source, seed hash, data/weights for ML) are the real ones.
+
+## Out of scope (explicitly not claimed)
+
+- **Correctness.** Provenance ≠ correctness. A signed, reproducible result can be
+  wrong. Compilation proves *accepted by the binary you run*, not *correct*.
+- **Numerical truth.** A signature proves *who signed these bytes*, not that the
+  number is mathematically right (see [NUMERICS.md](NUMERICS.md)).
+- **Trusting-trust.** Byte-identical self-hosting does **not** prove the binary
+  faithfully implements the source — a malicious seed could reproduce itself while
+  miscompiling. **A Rail compiler verifying a Rail compiler is not independent.**
+  Closing this needs a non-Rail check path (diverse double-compilation or an
+  independent reference checker) — it is *open work*, not a current guarantee.
+- **Side channels**, a compromised signing host, and supply-chain attacks upstream
+  of the pinned inputs.
+
+## The honest one-line version
+
+Rail makes computations **reproducible and auditable** by pinning and signing
+source, compiler, build products, and (for ML) per-step ledgers, anchored to a
+public beacon. That makes an undetected lie *expensive and detectable* — not
+impossible, and not a proof of truth.


### PR DESCRIPTION
Fugu recs #8 / #6 / #10 + Q3/Q5. Three contracts that ground the verifiability claims in the actual infra and are explicit about gaps:

- **NUMERICS.md** — bit-exact (integer/fixed-point, `mul_shr` 128-bit, the HF-parity ML path) vs deterministic-per-platform (IEEE 754 doubles) vs not-cross-platform (libm/GPU/x86). Scopes "bit-exact".
- **SAFE_SUBSET.md** — the hermetic subset + what is outside it (foreign/shell/raw-ptr/arena_reset/rc_*/#generate/libm/Metal).
- **THREAT_MODEL.md** — what is signed, who signs, what verifiers recompute, load-bearing assumptions, and what is NOT claimed (correctness, numerical truth, trusting-trust). Makes "undetected lie costs a conspiracy" falsifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmHLhbmQMwFjkzC5WLiu3Z