### PR TITLE
audit: stop two cry-wolf false-positives (pages regex + services_drift glob)

### DIFF
--- a/tools/audit/attest_endpoint_walk.sh
+++ b/tools/audit/attest_endpoint_walk.sh
@@ -241,7 +241,7 @@ class_pages() {
   # a static marketing page — confirmed 2026-05-27, no widget ever built.
   for page in system ot; do
     html=$(curl -sf "$BASE/$page")
-    if ! grep -qE '/?_shared/[a-z-]+-(live|attest|cite)\.js' <<<"$html"; then
+    if ! grep -qE '/?_shared/([a-z-]+-(live|attest|cite)|pulse-clock|proof-tray)\.js' <<<"$html"; then
       missing+=" $page"
     fi
   done

--- a/tools/audit/services_drift_audit.sh
+++ b/tools/audit/services_drift_audit.sh
@@ -36,7 +36,10 @@ claimed=$(awk '
   /^\*\*Currently running/ { in_block=1; next }
   in_block && /^\*\*/ { in_block=0 }
   in_block { print }
-' "$CLAUDE_MD" | grep -oE 'com\.ledatic\.[a-z_-]*[a-z0-9]' | sort -u)
+' "$CLAUDE_MD" | grep -v '_\*' | grep -oE 'com\.ledatic\.[a-z_-]*[a-z0-9]' | sort -u)
+# NB: grep -v '_\*' drops the family/summary rows ("8x com.ledatic.audit_*",
+# "~16x com.ledatic.lakes_*") so the glob suffix isn't mis-extracted as the
+# bare phantom services com.ledatic.audit / com.ledatic.lakes (NO_PLIST noise).
 
 if [[ -z "$claimed" ]]; then
   echo "FATAL: no claimed-running services found in $CLAUDE_MD"


### PR DESCRIPTION
Two audit walkers were false-failing:

- **attest_endpoint_walk** flagged /system as missing a live-data widget — but it ships pulse-clock.js / proof-tray.js under new names the regex did not match.
- **services_drift_audit** read the CLAUDE.md family rows (8x com.ledatic.audit_*, ~16x lakes_*) as literal services, producing phantom NO_PLIST verdicts.

Both were already fixed in the live crons this session; this ports them to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)