### PR TITLE
fix(deploy): per-level --out-prefix through the daily-deploy chain

### DIFF
--- a/tools/deploy/daily_deploy.rail
+++ b/tools/deploy/daily_deploy.rail
@@ -14,10 +14,10 @@ main =
   let _ = print (cat ["=== ", trim (shell "date -u"), " ==="])
 
   let _ = print "[1/2] Shared main.css + main.js + /llms.txt..."
-  let _ = print (shell "cd ~/projects/rail-https && ./rail_native run tools/deploy/gen_site.rail 2>&1")
+  let _ = print (shell "cd ~/projects/rail-https && ./rail_native --out-prefix /tmp/ledatic_deploy_c1 run tools/deploy/gen_site.rail 2>&1")
 
   let _ = print "[2/2] Atom feed (/feed.xml)..."
-  let _ = print (shell "cd ~/projects/rail-https && ./rail_native run tools/deploy/gen_feed.rail 2>&1")
+  let _ = print (shell "cd ~/projects/rail-https && ./rail_native --out-prefix /tmp/ledatic_deploy_c1 run tools/deploy/gen_feed.rail 2>&1")
 
   let _ = print "Daily deploy complete."
   0

--- a/tools/deploy/gen_feed.rail
+++ b/tools/deploy/gen_feed.rail
@@ -300,5 +300,5 @@ main =
   let _ = write_file "/tmp/feed.xml" feed
   let _ = print (cat ["wrote /tmp/feed.xml (", show (str_len feed), " bytes)"])
   let _ = print "deploying to Cloudflare KV..."
-  let _ = print (shell "./rail_native run tools/deploy/cf_deploy.rail /tmp/feed.xml feed.xml 2>&1")
+  let _ = print (shell "./rail_native --out-prefix /tmp/ledatic_deploy_c2 run tools/deploy/cf_deploy.rail /tmp/feed.xml feed.xml 2>&1")
   0

--- a/tools/deploy/gen_llms.rail
+++ b/tools/deploy/gen_llms.rail
@@ -71,7 +71,7 @@ main =
   let size = trim (shell (cat ["wc -c < ", f]))
   let _ = print (cat ["Generated: ", f, " (", size, " bytes)"])
   let _ = print "Deploying to Cloudflare KV as key: llms.txt"
-  let deploy_result = shell "./rail_native run tools/deploy/cf_deploy.rail /tmp/ledatic_llms.txt llms.txt 2>&1"
+  let deploy_result = shell "./rail_native --out-prefix /tmp/ledatic_deploy_c3 run tools/deploy/cf_deploy.rail /tmp/ledatic_llms.txt llms.txt 2>&1"
   let _ = print deploy_result
   let _ = shell "cp /tmp/ledatic_llms.txt ~/projects/ledatic-site/llms.txt"
 
@@ -86,7 +86,7 @@ main =
   let _ = print ""
   let _ = print (cat ["Generated: ", r, " (", rsize, " bytes)"])
   let _ = print "Deploying to Cloudflare KV as key: robots.txt"
-  let r_result = shell "./rail_native run tools/deploy/cf_deploy.rail /tmp/ledatic_robots.txt robots.txt 2>&1"
+  let r_result = shell "./rail_native --out-prefix /tmp/ledatic_deploy_c3 run tools/deploy/cf_deploy.rail /tmp/ledatic_robots.txt robots.txt 2>&1"
   let _ = print r_result
   let _ = shell "cp /tmp/ledatic_robots.txt ~/projects/ledatic-site/robots.txt"
 
@@ -121,7 +121,7 @@ main =
   let _ = print ""
   let _ = print (cat ["Generated: ", s, " (", ssize, " bytes)"])
   let _ = print "Deploying to Cloudflare KV as key: sitemap.xml"
-  let s_result = shell "./rail_native run tools/deploy/cf_deploy.rail /tmp/ledatic_sitemap.xml sitemap.xml 2>&1"
+  let s_result = shell "./rail_native --out-prefix /tmp/ledatic_deploy_c3 run tools/deploy/cf_deploy.rail /tmp/ledatic_sitemap.xml sitemap.xml 2>&1"
   let _ = print s_result
   let _ = shell "cp /tmp/ledatic_sitemap.xml ~/projects/ledatic-site/sitemap.xml"
 

--- a/tools/deploy/gen_site.rail
+++ b/tools/deploy/gen_site.rail
@@ -552,7 +552,7 @@ main =
   -- refresh /llms.txt on the daily cron.
   let _ = print ""
   let _ = print "Refreshing /llms.txt..."
-  let llms_result = shell "cd ~/projects/rail-https && ./rail_native run tools/deploy/gen_llms.rail 2>&1"
+  let llms_result = shell "cd ~/projects/rail-https && ./rail_native --out-prefix /tmp/ledatic_deploy_c2 run tools/deploy/gen_llms.rail 2>&1"
   let _ = print llms_result
   let _ = print "Done."
   0


### PR DESCRIPTION
The deploy pipeline nests `rail_native` four levels deep (daily_deploy → gen_site/gen_feed → gen_llms → cf_deploy), every level compiling to the default `/tmp/rail_out`. A child's compile overwrites its still-executing ancestor's binary; the ancestor's next page-fault is then killed by the kernel for a code-signature mismatch, and its buffered output is lost — a scheduled run of this chain died exactly this way (last exit reason `OS_REASON_CODESIGNING`, empty log).

**Fix:** each spawn depth compiles to its own out path (`_c1`/`_c2`/`_c3`), so no compile can overwrite an executing ancestor. Sequential siblings safely share a level prefix, and the chain stops contending with other users of the default out path (test suite, manual runs).

Verified argv passthrough: `rail_native --out-prefix /tmp/x run f.rail a b` → args arrive intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb4TJEdqhSKkRdLsDYD2JF