### PR TITLE
release: v5.3.0 — Independence + 3× faster self-compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to Rail are documented here.
 
+## v5.3.0 — 2026-07-08 — Independence + 3× faster self-compile
+
+Consolidation release: 19 PRs since v5.2.0.  Two headlines — a
+**non-Rail independence checker** (the trusting-trust answer: the
+committed seed no longer asks you to trust Rail to check Rail), and the
+**self-compile dropping 61 s → 19.2 s (3.2×)**.
+
+### Verify & trust
+- **Independence checker, Phase 3a** (#37): a reference checker written
+  outside Rail re-derives the integer core independently.
+- **One-command "check me" kit** (#32): `VERIFY.md` +
+  `tools/verify/check.sh`.
+- **Public reproducible-build check** (#23): `verify_reproducible.sh`
+  rebuilds the committed seed from source and compares hashes; verified
+  cross-host (#22) and re-verified nightly since.
+- **Self-generated truth matrix** (#31): `docs/STATUS.md` is emitted by
+  Rail from its own verified state.
+- **Grounding contracts** (#34): numerics, attested subset, threat model.
+- **Differential fuzzer covers integer div/mod** (#35), with a ±inf
+  false-positive fix.
+- **Leak-guard pre-check + pre-push hook** (#25).
+
+### Performance
+- **Self-compile 61 s → 34.6 s** (#29: parser cursor O(N²) → O(N))
+  **→ 19.2 s** (#36: exact-size GC free-list buckets, 16/24 B).
+- **Autograd and JIT tapes O(n²) → O(n)** (#27, #28): array-backed
+  tape build and backprop.
+
+### Language & robustness
+- **Multi-argument lambdas** `\a b -> e` (#33).
+- Free-var/env empty-checks use `== []`, not `length==0` — removes a
+  latent O(N³) on deep programs (#39).
+
+### Docs & ops
+- Truth reconciliation: getting-started/README/builtins reconciled with
+  v5.2.0 reality (#26); public claims scoped to what is true (#30);
+  Fugu re-review addressed (#38).
+- Fleet TB self-heal from hardware truth (#24); audit walkers lose two
+  cry-wolf false-positives (#40).
+
+178/178 tests.  The committed seed remains bit-reproducible — the
+nightly reproducibility witness stayed green throughout the series.
+
 ## v5.2.0 — 2026-06-19 — Rail stands alone (no as/ld/codesign)
 
 Major milestone.  The compiler now assembles, links, and code-signs

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <p align="center">
-  <a href="#releases"><img src="https://img.shields.io/badge/v5.2.0-Stands%20alone%20(no%20as%2Fld%2Fcodesign)-ff5500?style=for-the-badge" alt="v5.2.0"></a>
+  <a href="#releases"><img src="https://img.shields.io/badge/v5.3.0-Independence%20%2B%203%C3%97%20faster%20self--compile-ff5500?style=for-the-badge" alt="v5.3.0"></a>
 </p>
 
 <p align="center">
@@ -165,6 +165,15 @@ main =
 Tail-recursive loops match C `-O2` (5 instructions per iteration). The full architecture is documented in [`CHANGELOG.md`](CHANGELOG.md) — see v2.0.0 for the compiler/runtime; v3.0.0 for the TLS stack.
 
 ## Releases
+
+### v5.3.0 — 2026-07-08 — *Independence + 3× faster self-compile*
+
+19 PRs of consolidation: the trusting-trust answer plus a big perf cut.
+
+- **Independence checker.** A reference checker written *outside* Rail re-derives the integer core — the committed seed no longer asks you to trust Rail to check Rail. Alongside it: a one-command check-me kit (`VERIFY.md` + `tools/verify/check.sh`) and a self-generated truth matrix (`docs/STATUS.md`).
+- **Self-compile 61 s → 19.2 s (3.2×).** Parser cursor O(N²)→O(N) and exact-size GC free-list buckets; autograd + JIT tapes go O(n²)→O(n) as well.
+- **Multi-argument lambdas** (`\a b -> e`), integer div/mod differential fuzzing, grounding contracts (numerics / attested subset / threat model), and truth-reconciled docs. 178/178 tests; the seed stays bit-reproducible (nightly witness green throughout).
+
 
 ### v5.2.0 — 2026-06-19 — *Rail stands alone (no as/ld/codesign)*
 


### PR DESCRIPTION
Cuts v5.3.0 at current master (`9d8189a`) — 19 PRs of consolidation since v5.2.0 (#22–#40). CHANGELOG.md carries the canonical notes; README gets the badge + a Releases entry.

**Headlines**
- **Independence checker (Phase 3a, #37)** — a non-Rail reference checker re-derives the integer core: the trusting-trust answer.
- **Self-compile 61 s → 19.2 s (3.2×)** — parser cursor O(N²)→O(N) (#29) + exact-size GC free-list buckets (#36); autograd/JIT tapes O(n²)→O(n) (#27/#28).
- **Multi-argument lambdas** (#33), check-me kit (#32), truth matrix (#31), grounding contracts (#34), div/mod fuzzing (#35), truth-reconciled docs (#26/#30/#38).

Release candidate is reproducible as-committed: the nightly witness has rebuilt `9d8189a` from source to the byte-identical seed for 5 consecutive days.

After merge: tag `v5.3.0` on the merge commit (annotation = one-liner referencing CHANGELOG.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb4TJEdqhSKkRdLsDYD2JF