### PR TITLE
scrub: parametrize operator specifics out of the tree; extend the leak-guard

### DIFF
--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -43,14 +43,15 @@ jobs:
             set -e
             # Operator-recon + fleet/CGNAT + client + drone-canary + secret shapes.
             # CGNAT range covers all current+future 100.64.0.0/10 tailnet IPs
-            # (old guard hardcoded 5 specific IPs and missed the live Studio
-            # node 100.97.7.123 and the roof Pi 100.115.30.12).
+            # (the old guard hardcoded specific IPs and missed newer tailnet
+            # nodes; never write live node IPs here — this file is excluded
+            # from its own scan).
             # NB: bare ZEMOG/AIGP word-patterns are intentionally NOT here — they
             # false-match CLAUDE.md/SHIMS.md meta-docs that legitimately state the
             # drone code is PRIVATE. Drone protection = the tools/uav/ gitignore +
             # the private repo; MAVSDK stays as a flight-code canary. (macOS git
             # grep ignores \b — verify \b-patterns on Linux/CI, not locally.)
-            patterns='100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}|zemog@|user@100|reillygomez@|ledaticempire@|/Users/ledaticempire|/Users/reillygomez|/Users/user|/home/zemog|\bDetro\b|D0ATHQ1BQD7|\bbrockbro2\b|MAVSDK|Great Lakes|Drive Digital|slack_token[[:space:]]*=|BEACON_TOKEN[[:space:]]*=[[:space:]]*[A-Za-z0-9]'
+            patterns='100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}|zemog@|user@100|reillygomez@|ledaticempire@|/Users/ledaticempire|/Users/reillygomez|/Users/user|/home/zemog|\bDetro\b|D0ATHQ1BQD7|\bbrockbro2\b|MAVSDK|Great Lakes|Drive Digital|slack_token[[:space:]]*=|BEACON_TOKEN[[:space:]]*=[[:space:]]*[A-Za-z0-9]|10\.42\.[0-9]{1,3}\.[0-9]{1,3}|10\.(79|87|97|109|115|120)\.[0-9]{1,3}\.[0-9]{1,3}|Lakes (lab|integration|engagement|client)'
             # Excludes:
             #   - the guard itself (documents the patterns)
             #   - CHANGELOG.md (records the scrubs)

--- a/tools/apps/brain.rail
+++ b/tools/apps/brain.rail
@@ -37,7 +37,13 @@ get_trader_status =
   else "Trader: DOWN"
 
 get_wallet =
-  let bal = trim (shell "curl -s 'https://api.mainnet-beta.solana.com' -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getBalance\",\"params\":[\"AAEvGUF8ahT9rinivbwS7YASMvyfM4f6iRwgYPjoRqaA\"]}' 2>/dev/null | grep -o '\"value\":[0-9]*' | cut -d: -f2")
+  let addr = trim (shell "cat ~/.ledatic/wallet_pubkey 2>/dev/null")
+  if length addr == 0 then "Wallet: no pubkey (put the address in ~/.ledatic/wallet_pubkey)"
+  else get_wallet_balance addr
+
+get_wallet_balance addr =
+  let cmd = cat ["curl -s 'https://api.mainnet-beta.solana.com' -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getBalance\",\"params\":[\"", addr, "\"]}' 2>/dev/null | grep -o '\"value\":[0-9]*' | cut -d: -f2"]
+  let bal = trim (shell cmd)
   if length bal > 0 then cat ["Wallet: ", bal, " lamports"]
   else "Wallet: check failed"
 

--- a/tools/audit/attest_endpoint_walk.sh
+++ b/tools/audit/attest_endpoint_walk.sh
@@ -4,8 +4,8 @@
 # Endpoint audit walker — Phase 1 of docs/plans/ATTEST_ENDPOINT_AUDIT.md.
 # Probes each public attestation surface, reports per-class verdict + counters.
 #
-# READ-ONLY. No healing. No chain write yet (Phase 2 — gated on Studio :9101
-# /lab/entry route from the Lakes lab integration plan).
+# READ-ONLY. No healing. No chain write yet (Phase 2 — gated on a planned
+# internal lab-entry route).
 #
 # Exit code: 0 if every class PASS, 1 if any class FAIL, 2 on probe error.
 #

--- a/tools/bench/README.md
+++ b/tools/bench/README.md
@@ -93,7 +93,7 @@ a property of the substrate, not of any one model.
 For users running their own MLX or vLLM endpoint with a 100B+ model:
 
 ```bash
-# Default endpoint: http://10.42.0.2:8082 (Studio-internal)
+# Default endpoint: http://localhost:8082 (e.g. an SSH tunnel to the MLX host; override MLX_ENDPOINT)
 bash tools/bench/repro_30of30.sh
 
 # Override:
@@ -172,7 +172,7 @@ their own results with the same toolchain.
 - **`split` is single-character in Rail.** The `count_lines` and
   `first_line` prompts deliberately exercise this; the spec does not
   paper over it.
-- **MLX endpoint is hardcoded to Studio-internal `10.42.0.2:8082`** in
+- **MLX endpoint is hardcoded to the MLX host (default `localhost:8082`)** in
   `tools/train/spec_in_context_probe_full.py`. Override the env var
   `MLX_ENDPOINT` for the auto-detect probe in `repro_30of30.sh`; for the
   Python file directly, edit the `ENDPOINT` constant.

--- a/tools/bench/repro_30of30.sh
+++ b/tools/bench/repro_30of30.sh
@@ -2,7 +2,7 @@
 # repro_30of30.sh — one-line reproduction of the canonical 30/30 substrate result.
 #
 # Auto-detects an environment that can run the bench:
-#   1. If the local MLX teacher (Studio-internal http://10.42.0.2:8082) is
+#   1. If the local MLX teacher (the MLX teacher (default http://localhost:8082, e.g. over an SSH tunnel)) is
 #      reachable, runs the canonical probe at
 #      tools/train/spec_in_context_probe_full.py.
 #   2. Else, if ANTHROPIC_API_KEY is set, runs tools/bench/repro_anthropic.py
@@ -21,7 +21,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 RAIL_NATIVE="$REPO_ROOT/rail_native"
 MLX_PROBE="$REPO_ROOT/tools/train/spec_in_context_probe_full.py"
 ANTHROPIC_PROBE="$REPO_ROOT/tools/bench/repro_anthropic.py"
-MLX_ENDPOINT="${MLX_ENDPOINT:-http://10.42.0.2:8082}"
+MLX_ENDPOINT="${MLX_ENDPOINT:-http://localhost:8082}"
 
 usage() {
     cat <<'USAGE'
@@ -37,7 +37,7 @@ rerank). Auto-detects which backend to use:
       ANTHROPIC_API_KEY=... tools/bench/repro_30of30.sh
 
   Path B (local MLX — Studio-internal):
-    Requires the MLX teacher reachable at http://10.42.0.2:8082 (override
+    Requires the MLX teacher reachable at http://localhost:8082 (override
     via MLX_ENDPOINT env var). No external cost, ~15 min wall-clock.
 
       tools/bench/repro_30of30.sh
@@ -90,7 +90,7 @@ else
     echo
     echo "  Path B (local MLX teacher):"
     echo "    Run a 100B+ open-weight model (e.g. Qwen-122B) on an MLX or vLLM"
-    echo "    endpoint. By default this script probes http://10.42.0.2:8082."
+    echo "    endpoint. By default this script probes http://localhost:8082."
     echo "    Override: MLX_ENDPOINT=http://your-host:port bash $0"
     echo
     echo "  See tools/bench/README.md for full setup."

--- a/tools/fleet/README.md
+++ b/tools/fleet/README.md
@@ -23,7 +23,7 @@ within 30 s. Walk-away.
 ### Install (per node)
 
 ```bash
-echo "10.42.0.X" > ~/.fleet/tb-ip           # Mini=.1, Studio=.2, Air=.3
+echo "10.42.0.X" > ~/.fleet/tb-ip           # Mini=.1, Studio=.2, Air=.3 (leak-guard-allow: convention example)
 sudo cp tools/fleet/com.ledatic.tb_autojoin.plist /Library/LaunchDaemons/
 sudo chown root:wheel /Library/LaunchDaemons/com.ledatic.tb_autojoin.plist
 sudo chmod 644        /Library/LaunchDaemons/com.ledatic.tb_autojoin.plist

--- a/tools/fleet/heal.sh
+++ b/tools/fleet/heal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Fleet self-healer — Mini node
 # Detects & repairs the class of failures we hit on 2026-04-18:
-#   - bridge0 alias 10.42.0.1 vanishes when Internet Sharing toggles
+#   - bridge0 alias 10.42.0.1 vanishes when Internet Sharing toggles  # leak-guard-allow (fabric convention, private range)
 #   - new TB peer interfaces appear but don't auto-join bridge0
 #   - token file ends up world-readable or empty
 #   - fleet agent crashes silently

--- a/tools/fleet/rotate_fleet_token.sh
+++ b/tools/fleet/rotate_fleet_token.sh
@@ -17,12 +17,14 @@
 
 set -euo pipefail
 
-NODES=(
-  "mini:localhost:10.42.0.1"
-  "studio:studio:10.42.0.2"
-  "air:<peer-user>@<peer-host>:10.42.0.3"
-  "pi:<witness-user>@<witness-host>:10.87.231.45"   # Pi uses Tailscale IP
-)
+# Node list comes from ~/.fleet/nodes_ssh — one "name:ssh_target:agent_ip"
+# per line — so no fleet addressing lives in the public tree.
+NODES=()
+while IFS= read -r line; do
+  case "$line" in ""|\#*) continue;; esac
+  NODES+=("$line")
+done < "$HOME/.fleet/nodes_ssh"
+[ ${#NODES[@]} -gt 0 ] || { echo "no nodes in ~/.fleet/nodes_ssh" >&2; exit 1; }
 
 NEW_TOKEN=$(openssl rand -hex 32)
 NEW_MD5=$(printf '%s' "$NEW_TOKEN" | md5 -q 2>/dev/null || printf '%s' "$NEW_TOKEN" | md5sum | awk '{print $1}')

--- a/tools/train/harvest_teacher.rail
+++ b/tools/train/harvest_teacher.rail
@@ -2,7 +2,7 @@
 --
 -- Walks the existing `training/triples_v2.txt` corpus, extracts each
 -- (broken, diag) pair, prompts Qwen 3.6 35B (teacher on Studio MLX
--- 10.42.0.2:8081) for a fix, compiles the teacher's response, and
+-- localhost:8081) for a fix, compiles the teacher's response, and
 -- emits a triple if it compiles cleanly. Discards the existing FIXED
 -- block — we want a SECOND, independently-generated fix for the same
 -- failure, broadening the fix-distribution the model gets to imitate.
@@ -20,7 +20,7 @@ import "stdlib/llm.rail"
 import "jit/ir.rail"
 import "tools/train/diagnose_jit.rail"
 
-teacher_ip = "10.42.0.2"
+teacher_ip = "localhost"  -- MLX teacher host (e.g. an SSH tunnel)
 teacher_port = "8081"
 teacher_model = "~/models/Qwen3.6-35B-A3B-8bit"
 

--- a/tools/train/spec_in_context_probe.py
+++ b/tools/train/spec_in_context_probe.py
@@ -7,7 +7,7 @@ Two arms:
   naked: just the bench prompt, no Rail-specific priming
   spec:  Rail self-spec prefix + the bench prompt
 
-Calls Studio's local Qwen-122B-A10B at 10.42.0.2:8088 (OpenAI-compatible
+Calls Studio's local Qwen-122B-A10B at localhost:8088 (OpenAI-compatible
 mlx_lm.server). N=3 reranks per (prompt, arm). Grades each completion
 with `./rail_native parse-check` AND `./rail_native FILE` (full compile).
 
@@ -16,13 +16,14 @@ Usage:
 """
 from __future__ import annotations
 import json
+import os
 import subprocess
 import sys
 import urllib.request
 import urllib.error
 from pathlib import Path
 
-ENDPOINT = "http://10.42.0.2:8088/v1/chat/completions"
+ENDPOINT = os.environ.get("MLX_ENDPOINT", "http://localhost:8088/v1/chat/completions")
 MODEL = "mlx-community/Qwen3.5-122B-A10B-heretic-v2-2.34bit-msq"
 N_RERANK = 3
 MAX_TOKENS = 256

--- a/tools/train/spec_in_context_probe_full.py
+++ b/tools/train/spec_in_context_probe_full.py
@@ -3,13 +3,14 @@
 spec_in_context_probe_full.py — substrate hard-bench probe.
 
 All 30 bench prompts (6 bands × 5) × N=10 reranks against Studio's 122B
-teacher at 10.42.0.2:8082. Compile-grade each generation via rail_native.
+teacher at localhost:8082. Compile-grade each generation via rail_native.
 Pass = ANY of the N completions compiles cleanly (exit 0).
 
 Output: per-prompt PASS/FAIL, per-band totals, overall score and wall-clock.
 """
 from __future__ import annotations
 import json
+import os
 import subprocess
 import sys
 import time
@@ -17,7 +18,7 @@ import urllib.request
 import urllib.error
 from pathlib import Path
 
-ENDPOINT = "http://10.42.0.2:8082/v1/chat/completions"
+ENDPOINT = os.environ.get("MLX_ENDPOINT", "http://localhost:8082/v1/chat/completions")
 MODEL = "mlx-community/Qwen3.5-122B-A10B-heretic-v2-2.34bit-msq"
 N_RERANK = 20
 MAX_TOKENS = 256


### PR DESCRIPTION
Follow-up to #44 (stacked on it; diff is now just the scrub).

- `brain.rail` reads the wallet pubkey from a local config file instead of embedding an address.
- `rotate_fleet_token.sh` reads its node list from `~/.fleet/nodes_ssh` — the embedded map (which carried a half-scrubbed address remnant) is gone.
- bench/probe/harvest tooling defaults to `localhost` tunnel endpoints with `MLX_ENDPOINT` overrides.
- `attest_endpoint_walk.sh` comment de-specified.
- **leak-guard hardened**: no addresses in its own comments (it's excluded from its own scan), pattern set extended to the private-fabric range, mangled-remnant shapes, and engagement-phrase forms. Two intentional fabric-convention doc lines carry `leak-guard-allow`. Full-tree scan with the extended set: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb4TJEdqhSKkRdLsDYD2JF