### PR TITLE
Land Mini-local hardening: fleet fail-closed auth, gitleaks allowlist, system_page audit fix

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,41 @@
+# gitleaks config for zemo-g/rail. Keeps all default rules, allowlists the
+# verified false positives so a future finding actually means something (usable
+# as a CI gate). Every entry below was traced to a non-secret on 2026-07-02:
+#   - cached RFC spec text (published examples)
+#   - TLS 1.3 key-DERIVATION variable names (computed at runtime, not literals)
+#   - the RFC 8032 Ed25519 test vectors
+#   - ephemeral TLS handshake secrets from a past test session (dead on session end)
+#   - a model name
+# Add new allowlist entries ONLY after confirming the match is not a real secret.
+
+title = "Ledatic rail gitleaks"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Verified false positives (see header)"
+
+# Cached RFC specifications — published example tokens/keys, by definition public.
+paths = [
+  '''tools/dnra/cache/rfc/.*''',
+]
+
+regexes = [
+  # TLS 1.3 key/iv derivation calls in the pure-Rail TLS stack — these are
+  # variable assignments to runtime-derived values, not embedded secrets.
+  '''tls13_derive_(key|iv)''',
+  # RFC 8032 Ed25519 test vector (secret + public key) used in signing docs.
+  '''9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60''',
+  '''d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a''',
+  # Ephemeral TLS 1.3 handshake secrets captured in a dev handoff (per-session,
+  # dead the moment that test handshake ended).
+  '''8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d''',
+  '''1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac''',
+  # Model identifier flagged as a "key".
+  '''Qwen2\.5-1\.5B-Instruct''',
+  # Dead API_BEARER hardcoded in the April worker (commit 7cebc94a), superseded
+  # by a Cloudflare secret binding. Verified 2026-07-02 to NOT equal the live
+  # production token (~/.ledatic/api/bearer_token) — grants nothing.
+  '''YW4poVpINEaOEsPctzf8FRPTmycXHbH7lFyjRVRqsnc''',
+]

--- a/tools/audit/system_page_audit.sh
+++ b/tools/audit/system_page_audit.sh
@@ -25,7 +25,16 @@ while (( $# )); do
 done
 
 BASE="${LEDATIC_BASE:-https://ledatic.org}"
-RAIL_DIR="${HOME}/projects/rail"
+# The /system page advertises PUBLIC rail (origin/master), so verify against a
+# master-TRACKING reference, NOT a working clone -- those sit on feature branches
+# with divergent test counts, which caused the 2026-07-07 171-vs-178 false FAIL
+# (the working clone was on security/gitleaks-config@171; origin/master actually
+# tests 178, matching the page). Self-refresh to latest origin/master each run.
+RAIL_DIR="${RAIL_MASTER_REF:-${HOME}/.fleet/rail-master-ref}"
+if [[ -e "$RAIL_DIR/.git" ]]; then
+  git -C "$RAIL_DIR" fetch --quiet origin master 2>/dev/null \
+    && git -C "$RAIL_DIR" reset --hard --quiet origin/master 2>/dev/null || true
+fi
 PAGE=/tmp/system_audit.html
 
 total_pass=0
@@ -53,8 +62,10 @@ curl -sf "$BASE/system" -o "$PAGE" || { echo "FATAL: could not fetch /system"; e
 # ============================================================================
 class_rail_version() {
   local page_ver tag_ver
-  # Header reads e.g. "RAIL v5.1.0 · 141/141"
-  page_ver=$(grep -oE 'RAIL v[0-9]+\.[0-9]+\.[0-9]+' "$PAGE" | head -1 | awk '{print $2}')
+  # Page carries the version as an attested <data> element, e.g.
+  # <data pulse="...">v5.2.0</data> (format moved off the old "RAIL v5.1.0"
+  # header string 2026-07 — match the bare vX.Y.Z anywhere).
+  page_ver=$(grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' "$PAGE" | head -1)
   tag_ver=$(cd "$RAIL_DIR" && git tag --list 'v*' | sort -V | tail -1)
   log "page: $page_ver  substrate: $tag_ver"
   if [[ "$page_ver" == "$tag_ver" ]]; then

--- a/tools/fleet/fleet_agent_v3.rail
+++ b/tools/fleet/fleet_agent_v3.rail
@@ -105,7 +105,7 @@ clean s =
   trim (shell "sed 's/^[[:space:]]*//' /tmp/_fleet_v3_clean.txt | tr -d '\\015'")
 
 check_auth headers token =
-  if length token == 0 then true
+  if length token == 0 then false   -- fail CLOSED: no token configured = deny all
   else
     let raw = get_header headers "X-Fleet-Token"
     let provided = clean raw
@@ -122,16 +122,23 @@ filter_nonempty lines =
     if length l > 0 then cons l (filter_nonempty (tail lines))
     else filter_nonempty (tail lines)
 
+-- Shell-metacharacter set + contains_any: a reusable guard, kept for a
+-- future safe dynamic-arg validator. NOT currently wired into cmd_allowed,
+-- which is exact-match only (see its note) — so injection is already
+-- impossible. (Was added when the prefix-match path existed.)
+shell_metas _ = [";", "|", "&", "$", "`", ">", "<", "(", ")", "{", "}", "\n", "\\"]
+
+contains_any s metas =
+  if length metas == 0 then false
+  else if str_find (head metas) s >= 0 then true
+  else contains_any s (tail metas)
+
 cmd_allowed cmd whitelist =
   if length whitelist == 0 then false
   else
     let entry = head whitelist
     if cmd == entry then true
-    else
-      let prefix = cat [entry, " "]
-      let check = trim (shell (cat ["echo ", q, cmd, q, " | cut -c1-", show (length prefix)]))
-      if check == entry then true
-      else cmd_allowed cmd (tail whitelist)
+    else cmd_allowed cmd (tail whitelist)
 
 -- Extract "cmd" from JSON body
 extract_cmd body =


### PR DESCRIPTION
Cherry-picks three Mini-local commits onto master (originals sat on a stale local branch):

- **fleet_agent_v3: exact-match whitelist + fail-closed auth** (519a18b) — the deployed fleet control plane has run this hardening since 07-08; this lands the source.
- **.gitleaks.toml allowlist** (dc78286) — clean full-history scan config.
- **system_page audit: verify against origin/master, not a working clone; fix stale version regex** (d71814e).

Local: 187/187 suite pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb4TJEdqhSKkRdLsDYD2JF