### PR TITLE
attest: write latest-record pointers; stop llms.txt hardcoding stats

### DIFF
--- a/tools/attest/attest_selfhost.sh
+++ b/tools/attest/attest_selfhost.sh
@@ -85,3 +85,22 @@ else
   echo "NOT a fixed point: pass1=${pass1_sha:0:16} pass2=${pass2_sha:0:16}" >&2
 fi
 echo "selfhost attested: $dest/"
+
+# Latest-record pointer. Written here, at the moment a record exists, rather
+# than derived later by listing directories: the pure-Rail origin that serves
+# this is single-threaded and also carries the site's live pulse, so it must
+# read a file, not fork a subprocess, per request. Kept outside the checkout
+# so the pristine master worktree stays clean.
+POINTER_DIR=${POINTER_DIR:-$HOME/.ledatic/attest}
+mkdir -p "$POINTER_DIR"
+python3 -c "
+import json, sys, time
+print(json.dumps({
+  'kind': 'ledatic.selfhost.latest',
+  'short': sys.argv[1],
+  'updated_utc': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+}))
+" "$short" > "$POINTER_DIR/selfhost_latest.json.tmp" \
+  && mv -f "$POINTER_DIR/selfhost_latest.json.tmp" "$POINTER_DIR/selfhost_latest.json"
+echo "latest pointer: $POINTER_DIR/selfhost_latest.json -> $short"
+

--- a/tools/attest/attest_test_run.sh
+++ b/tools/attest/attest_test_run.sh
@@ -82,3 +82,22 @@ echo "----"
 cat "$result"
 echo "----"
 echo "build attested: $dest/"
+
+# Latest-record pointer. Written here, at the moment a record exists, rather
+# than derived later by listing directories: the pure-Rail origin that serves
+# this is single-threaded and also carries the site's live pulse, so it must
+# read a file, not fork a subprocess, per request. Kept outside the checkout
+# so the pristine master worktree stays clean.
+POINTER_DIR=${POINTER_DIR:-$HOME/.ledatic/attest}
+mkdir -p "$POINTER_DIR"
+python3 -c "
+import json, sys, time
+print(json.dumps({
+  'kind': 'ledatic.builds.latest',
+  'short': sys.argv[1],
+  'updated_utc': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+}))
+" "$short" > "$POINTER_DIR/builds_latest.json.tmp" \
+  && mv -f "$POINTER_DIR/builds_latest.json.tmp" "$POINTER_DIR/builds_latest.json"
+echo "latest pointer: $POINTER_DIR/builds_latest.json -> $short"
+

--- a/tools/audit/aliens_manifest_audit.sh
+++ b/tools/audit/aliens_manifest_audit.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 # tools/audit/aliens_manifest_audit.sh
 #
-# /pursue manifest re-hash audit. Picks the smallest record, verifies
-# size + sha256 against what the manifest claims.
+# /pursue manifest re-hash audit.
+#
+# Reworked 2026-07-25 for the free-tier posture. The old version sampled the
+# smallest DOCUMENT and required it to be fetchable — true only while R2 was
+# mirroring 10.5 GB of PDFs. Document bytes are now deliberately withheld (CF
+# ToS §2.8 on a Free zone; war.gov 403s us, so there is no upstream to
+# redirect to either), which made this audit exit FATAL every day on a policy
+# rather than a fault.
+#
+# The invariant that still earns its keep is the one the archive rests on:
+# NOTHING IS SERVED THAT FAILS ITS OWN ATTESTATION. So this samples what we do
+# serve — the digest-verified thumbnails — and re-hashes them against the
+# manifest. Withheld is expected and never a failure; drift on a served
+# artifact is.
 #
 # See docs/plans/ALIENS_MANIFEST_AUDIT.md.
 #
@@ -23,6 +35,7 @@ done
 BASE="${LEDATIC_BASE:-https://ledatic.org}"
 MANIFEST_PATH="${MANIFEST_PATH:-/pursue/manifest.jsonl}"
 MANIFEST=/tmp/aliens_manifest.jsonl
+SAMPLE_N="${SAMPLE_N:-3}"
 
 log()    { (( QUIET )) || echo "  $*"; }
 header() { (( QUIET )) || echo "--- $* ---"; }
@@ -36,87 +49,109 @@ records=$(wc -l <"$MANIFEST" | tr -d ' ')
 (( QUIET )) || echo "manifest: $BASE$MANIFEST_PATH ($records records)"
 (( QUIET )) || echo
 
-# ---- 2. Pick smallest record --------------------------------------------
+# ---- 2. Candidate served artifacts (thumbnails, smallest first) ----------
+# A thumbnail path is published only when every record citing it agrees on one
+# digest, so sampling by path is well-defined. Smallest-first keeps the audit
+# cheap and deterministic. Serial fetches on purpose: hammering our own CDN in
+# parallel trips bot protection, and then you are hashing a challenge page.
 header "sample selection"
-# Extract size_bytes + local_path + sha256 per line; tolerate whitespace.
-# Find smallest by size. One line per JSON record.
-sample=$(while IFS= read -r line; do
-  s=$(echo "$line" | grep -oE '"size_bytes"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' | head -1)
-  p=$(echo "$line" | grep -oE '"local_path"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*"local_path"[[:space:]]*:[[:space:]]*"//;s/"$//' | head -1)
-  # First sha256 in record is the main file's (thumbnail_sha256 comes later)
-  h=$(echo "$line" | grep -oE '"sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]+"' | head -1 | grep -oE '[0-9a-f]{64}')
-  [[ -n "$s" && -n "$p" && -n "$h" ]] && printf '%s\t%s\t%s\n' "$s" "$p" "$h"
-done <"$MANIFEST" | sort -n | head -1)
-size_claimed=$(echo "$sample" | cut -f1)
-local_path=$(echo "$sample" | cut -f2)
-sha_claimed=$(echo "$sample" | cut -f3)
-log "smallest record: $local_path"
-log "claimed size: $size_claimed bytes"
-log "claimed sha256: ${sha_claimed:0:16}..."
+candidates=$(python3 - "$MANIFEST" "$SAMPLE_N" <<'PY'
+import json, sys, collections
+path, n = sys.argv[1], int(sys.argv[2])
+recs = [json.loads(l) for l in open(path) if l.strip()]
+digests = collections.defaultdict(set)
+for r in recs:
+    t = r.get("thumbnail_local")
+    if t:
+        digests[t].add(r.get("thumbnail_sha256"))
+rows = {}
+for r in recs:
+    t = r.get("thumbnail_local")
+    if not t or len(digests[t]) != 1:
+        continue                      # ambiguous path — correctly withheld
+    rows[t] = (r.get("thumbnail_size_bytes") or 0, t, r.get("thumbnail_sha256"))
+for size, t, sha in sorted(rows.values())[:n]:
+    print(f"{size}\t{t}\t{sha}")
+PY
+)
+[[ -n "$candidates" ]] || { echo "FATAL: no unambiguous thumbnail records in manifest"; exit 2; }
 
-if [[ -z "$size_claimed" || -z "$local_path" || -z "$sha_claimed" ]]; then
-  echo "FATAL: could not parse manifest fields"
-  exit 2
-fi
+# ---- 3. Verify each served candidate ------------------------------------
+fail=0; served=0; withheld=0
+while IFS=$'\t' read -r size_claimed local_path sha_claimed; do
+  [[ -n "$local_path" ]] || continue
+  rel=${local_path#files/}
+  encoded=$(python3 -c "import sys,urllib.parse;print('/'.join(urllib.parse.quote(p) for p in sys.argv[1].split('/')))" "$rel")
+  url="$BASE/pursue/files/$encoded"
+  tmp=/tmp/aliens_audit_sample.bin
+  rm -f "$tmp"
+  if ! curl -sf --max-time 40 "$url" -o "$tmp"; then
+    withheld=$((withheld + 1))
+    log "withheld (expected, not a failure): $rel"
+    continue
+  fi
+  served=$((served + 1))
+  size_actual=$(wc -c <"$tmp" | tr -d ' ')
+  sha_actual=$(shasum -a 256 "$tmp" | awk '{print $1}')
+  if [[ "$size_actual" != "$size_claimed" ]]; then
+    log "FAIL: size drift on $rel ($size_claimed claimed vs $size_actual actual)"
+    fail=1
+  elif [[ "$sha_actual" != "$sha_claimed" ]]; then
+    log "FAIL: sha256 drift on $rel"
+    log "  claimed: $sha_claimed"
+    log "  actual:  $sha_actual"
+    fail=1
+  else
+    log "ok  $rel  (${size_actual} B, ${sha_actual:0:16}…)"
+  fi
+  rm -f "$tmp"
+done <<<"$candidates"
 
-# ---- 3. HEAD: size check ------------------------------------------------
-header "size check"
-# URL-encode path segments (R2 keys with spaces, etc.)
-encoded_path=$(python3 -c "import sys, urllib.parse; print('/'.join(urllib.parse.quote(p) for p in sys.argv[1].split('/')))" "$local_path")
-url="$BASE/pursue/$encoded_path"
-size_actual=$(curl -sfI "$url" | grep -i '^content-length:' | awk '{print $2}' | tr -d '\r')
-log "url: $url"
-log "actual size: $size_actual bytes"
-
-fail=0
-if [[ "$size_actual" != "$size_claimed" ]]; then
-  log "FAIL: size drift ($size_claimed claimed vs $size_actual actual)"
+# A served set of zero means thumbnail publication silently lapsed — the
+# archive would render as placeholders and nobody would notice.
+if (( served == 0 )); then
+  log "FAIL: no sampled thumbnail was served — publication may have lapsed"
   fail=1
 fi
 
-# ---- 4. GET: sha256 check -----------------------------------------------
-header "sha256 check"
-tmp=/tmp/aliens_audit_sample.bin
-rm -f "$tmp"
-curl -sf "$url" -o "$tmp" || { echo "FATAL: GET failed for $url"; exit 2; }
-sha_actual=$(shasum -a 256 "$tmp" | awk '{print $1}')
-log "actual sha256: ${sha_actual:0:16}..."
-
-if [[ "$sha_actual" != "$sha_claimed" ]]; then
-  log "FAIL: sha256 drift"
-  log "  claimed: $sha_claimed"
-  log "  actual:  $sha_actual"
-  fail=1
+# ---- 4. Policy check: document bytes stay withheld -----------------------
+header "document withholding"
+doc=$(python3 - "$MANIFEST" <<'PY'
+import json, sys
+recs = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+recs = [r for r in recs if r.get("local_path")]
+r = min(recs, key=lambda r: r.get("size_bytes") or 0)
+print(r["local_path"][len("files/"):])
+PY
+)
+doc_enc=$(python3 -c "import sys,urllib.parse;print('/'.join(urllib.parse.quote(p) for p in sys.argv[1].split('/')))" "$doc")
+doc_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$BASE/pursue/files/$doc_enc")
+if [[ "$doc_code" == "404" ]]; then
+  log "ok  documents withheld as intended (sampled → 404)"
+else
+  log "NOTE: document bytes are being served again (sampled → $doc_code)"
+  log "      not a failure — but re-check the ToS §2.8 exposure decision"
 fi
-rm -f "$tmp"
 
 # ---- 5. Verdict ----------------------------------------------------------
 echo
 echo "=== SUMMARY ==="
-echo "sampled: $local_path"
+echo "sampled=$((served + withheld)) served=$served withheld=$withheld doc_probe=$doc_code"
 
 if (( LAB_MODE == 1 )); then
-  size_match=$([[ "$size_actual" == "$size_claimed" ]] && echo 1 || echo 0)
-  sha_match=$([[ "$sha_actual" == "$sha_claimed" ]] && echo 1 || echo 0)
   echo "===RAIL_LAB_COUNTERS==="
-  echo "{\"counter\": \"size_match\", \"value\": $size_match}"
-  echo "{\"counter\": \"sha_match\", \"value\": $sha_match}"
-  echo "{\"counter\": \"sampled_size_bytes\", \"value\": ${size_claimed:-0}}"
+  echo "{\"counter\": \"served_verified\", \"value\": $served}"
+  echo "{\"counter\": \"served_drifted\", \"value\": $fail}"
   echo "{\"counter\": \"manifest_records\", \"value\": ${records:-0}}"
   echo "===END==="
-  if (( fail == 0 )); then
-    echo "===VERDICT=== PASS"
-    exit 0
-  else
-    echo "===VERDICT=== FALSIFIED"
-    exit 0  # exit 0 in --lab mode: runner succeeded, verdict is the falsification claim
-  fi
+  if (( fail == 0 )); then echo "===VERDICT=== PASS"; else echo "===VERDICT=== FALSIFIED"; fi
+  exit 0
 fi
 
 if (( fail == 0 )); then
-  echo "VERDICT=PASS — sampled record matches manifest (size + sha256)"
+  echo "VERDICT=PASS — every served artifact matches its attestation"
   exit 0
 else
-  echo "VERDICT=FALSIFIED — drift detected on $local_path"
+  echo "VERDICT=FALSIFIED — a served artifact drifted from the manifest"
   exit 1
 fi

--- a/tools/deploy/gen_llms.rail
+++ b/tools/deploy/gen_llms.rail
@@ -32,12 +32,18 @@ main =
   -- Lede
   let _ = w f "LEDATIC is the engineering practice of Reilly Gomez, in Detroit, MI. The thesis: the post-AI internet needs an independent third-party trust layer for compute, and the same primitive scales from one artifact at your doorstep to every record in a government archive.\n\n"
 
-  -- The four working surfaces
-  let _ = w f "## The four working surfaces\n\n"
-  let _ = w f "1. **[Rail](https://ledatic.org/rail)** — the substrate. Self-hosting compiler, v5.1.0, 177/177 tests, ~1.3 MB ARM64 seed binary, byte-identical 2-pass fixed point. Pure-Rail TLS 1.3 (verified live against Amazon and Slack) plus JIT-emitted Metal GPU kernels. Six backends: native ARM64, Linux ARM64, Linux x86_64, WASM, Cortex-M4, RISC-V. BSL 1.1 on GitHub at `zemo-g/rail`.\n\n"
+  -- The working surfaces.
+  -- NOTE: no version / test-count / binary-size literals here. They were
+  -- hardcoded until 2026-07-25 and had rotted a full two releases out of date
+  -- (claiming v5.1.0 and 177 tests long after neither was true) — on the one
+  -- file written specifically for machines to read. Current values are served
+  -- live and cited rather than restated; a number that isn't typed can't rot.
+  let _ = w f "## The working surfaces\n\n"
+  let _ = w f "1. **[Rail](https://ledatic.org/rail)** — the substrate. A self-hosting compiler with no C in its runtime: it assembles, links and code-signs its own binary, and rebuilds itself to a byte-identical fixed point that matches the committed seed. Pure-Rail TLS 1.3 (verified live against real public APIs) plus JIT-emitted Metal GPU kernels. Six backends: native ARM64, Linux ARM64, Linux x86_64, WASM, Cortex-M4, RISC-V. BSL 1.1 on GitHub at `zemo-g/rail`. Current version, test count, module count and seed size are published as machine-readable JSON at [/_shared/stats.json](https://ledatic.org/_shared/stats.json); the live attested build and self-host records are at [/attest/latest](https://ledatic.org/attest/latest).\n\n"
   let _ = w f "2. **[Entropy](https://ledatic.org/entropy)** — the beacon. A live 2D ideal-MHD Orszag-Tang simulation on a 128x128 grid hashes its state every ~2 seconds into a public chain you can walk in one shell line. Conservation to machine precision. The plasma viewer is embedded on the page so you can see the bytes that just got SHA-256'd into the row above.\n\n"
   let _ = w f "3. **[Aliens](https://ledatic.org/aliens)** — the demo. A byte-for-byte mirror of the U.S. Dept. of War PURSUE UAP archive (gov.uap), each file Ed25519-signed against the beacon by an independent Pi witness (`pk_fp cac5f21a70564aeb`) and verifiable per-record in your own browser. The whole verifier chain (mirror + beacon + witness + browser-side Ed25519) is original.\n\n"
   let _ = w f "4. **[System](https://ledatic.org/system)** — mission control. Five live panels — beacon, witness, fleet, build, self-host. Every cell is a current value fetched from a signed JSON artifact at page load. If any of it's stale, this page shows it.\n\n"
+  let _ = w f "5. **[The oracle](https://ledatic.org/oracle)** — what the compiler is *for*. A model's claim that its code is correct is unfalsifiable; a compile is a fact anyone can reproduce. Ledatic trains models against the compiler as the fitness function, with bit-reproducible corpora bound into hash-chained, witness-signed ledgers. The page reports the result AND its limits, including a month-long self-improvement run whose entire signed capability climb turned out to be measurement noise once re-scored on a five-times-wider held-out sample. Attestation of a computation is not validation of its metric — that distinction is load-bearing here and is stated publicly rather than buried.\n\n"
 
   -- Direction
   let _ = w f "## Direction: proof-of-human-authorship\n\n"
@@ -96,10 +102,11 @@ main =
   let _ = shell (cat ["rm -f ", s])
   let _ = w s "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
   let _ = w s "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n"
-  -- Full live-page set (each verified 200). The four working surfaces first,
+  -- Full live-page set (each verified 200). The working surfaces first,
   -- then the verb, then supporting pages. Daily lastmod for the live panels.
   let _ = surl s "/" date "weekly" "1.0"
   let _ = surl s "/rail" date "weekly" "0.9"
+  let _ = surl s "/oracle" date "weekly" "0.9"
   let _ = surl s "/entropy" date "daily" "0.8"
   let _ = surl s "/aliens" date "weekly" "0.8"
   let _ = surl s "/system" date "daily" "0.8"


### PR DESCRIPTION
Three small things that all had the same shape — a published claim with nothing keeping it true. All three surfaced while restoring the attestation surface after the Cloudflare free-tier pivot retired R2.

### `tools/attest/attest_{test_run,selfhost}.sh` — write the latest-record pointer

`/attest/latest` and both shields badges walk a `<kind>/latest/index.json` pointer that used to be PUT straight to an R2-backed route. When R2 went, the endpoint returned `{builds:null,selfhost:null}` and stayed that way for weeks. The pointer is now written by the producer, at the moment a record exists.

Written by the producer rather than derived by listing directories on demand, deliberately: the pure-Rail origin serving this is single-threaded and also carries the site's public pulse, so it must read a file, not fork a subprocess, per request.

### `tools/deploy/gen_llms.rail` — stop hardcoding managed stats

It claimed **v5.1.0, 177/177 tests, ~1.3 MB** — two full releases out of date, on the one file written specifically for machines to read. Fixed by **removing** the literals rather than refreshing them: it now cites `/_shared/stats.json` and `/attest/latest`, where those values are served live. A number that isn't typed can't rot. Also adds the fifth working surface (`/oracle`) and puts it in the sitemap.

### `tools/audit/aliens_manifest_audit.sh` — assert the invariant that still holds

It required the smallest **document** to be fetchable — true only while R2 mirrored 10.5 GB of PDFs. Document bytes are now deliberately withheld (CF ToS §2.8 on a Free zone, and war.gov 403s us so there is no upstream to redirect to), so this exited FATAL every day on a policy rather than a fault.

Rewritten to assert what still earns its keep: **nothing is served that fails its own attestation** — sampled against the digest-verified thumbnails we do serve. Withheld is expected; drift on a served artifact is a failure. Serial fetches on purpose: parallel probes trip CF bot protection and you end up hashing a challenge page.

### Deliberately not included

`tools/audit/attest_endpoint_walk.sh`. My two edits there (dda class inverted to assert closure rather than reachability; fleet staleness 300s→900s to match the new KV write throttle) are live in the working clone — but that file also carries an uncommitted `class_frame_attest` from another session, and folding someone else's unreviewed work into my PR isn't mine to do. Worth landing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XJN17ZCyb5wuLUHXDxbs8