### PR TITLE
Land the live-run hardening the crons already execute

### DIFF
--- a/tools/attest/attest_selfhost.sh
+++ b/tools/attest/attest_selfhost.sh
@@ -85,3 +85,22 @@ else
   echo "NOT a fixed point: pass1=${pass1_sha:0:16} pass2=${pass2_sha:0:16}" >&2
 fi
 echo "selfhost attested: $dest/"
+
+# Latest-record pointer. Written here, at the moment a record exists, rather
+# than derived later by listing directories: the pure-Rail origin that serves
+# this is single-threaded and also carries the site's live pulse, so it must
+# read a file, not fork a subprocess, per request. Kept outside the checkout
+# so the pristine master worktree stays clean.
+POINTER_DIR=${POINTER_DIR:-$HOME/.ledatic/attest}
+mkdir -p "$POINTER_DIR"
+python3 -c "
+import json, sys, time
+print(json.dumps({
+  'kind': 'ledatic.selfhost.latest',
+  'short': sys.argv[1],
+  'updated_utc': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+}))
+" "$short" > "$POINTER_DIR/selfhost_latest.json.tmp" \
+  && mv -f "$POINTER_DIR/selfhost_latest.json.tmp" "$POINTER_DIR/selfhost_latest.json"
+echo "latest pointer: $POINTER_DIR/selfhost_latest.json -> $short"
+

--- a/tools/attest/attest_test_run.sh
+++ b/tools/attest/attest_test_run.sh
@@ -82,3 +82,22 @@ echo "----"
 cat "$result"
 echo "----"
 echo "build attested: $dest/"
+
+# Latest-record pointer. Written here, at the moment a record exists, rather
+# than derived later by listing directories: the pure-Rail origin that serves
+# this is single-threaded and also carries the site's live pulse, so it must
+# read a file, not fork a subprocess, per request. Kept outside the checkout
+# so the pristine master worktree stays clean.
+POINTER_DIR=${POINTER_DIR:-$HOME/.ledatic/attest}
+mkdir -p "$POINTER_DIR"
+python3 -c "
+import json, sys, time
+print(json.dumps({
+  'kind': 'ledatic.builds.latest',
+  'short': sys.argv[1],
+  'updated_utc': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+}))
+" "$short" > "$POINTER_DIR/builds_latest.json.tmp" \
+  && mv -f "$POINTER_DIR/builds_latest.json.tmp" "$POINTER_DIR/builds_latest.json"
+echo "latest pointer: $POINTER_DIR/builds_latest.json -> $short"
+

--- a/tools/attest/publish.sh
+++ b/tools/attest/publish.sh
@@ -52,6 +52,16 @@ publish_dir() {
     [ -f "$dir/rail_native"  ] && files+=("$dir/rail_native")
     [ -f "$dir/compile.rail" ] && files+=("$dir/compile.rail")
   fi
+  # bash 3.2 (what /bin/bash is on macOS, and what launchd runs) treats
+  # "${arr[@]}" on an EMPTY array as an unbound variable under `set -u`, so an
+  # attest run that produced no records killed this script with a cryptic
+  # "files[@]: unbound variable" instead of saying so. That is exactly what had
+  # been happening on the daily job. Say it plainly and fail — an empty record
+  # set means the attestation upstream did not finish, which is worth an alarm.
+  if [ ${#files[@]} -eq 0 ]; then
+    echo "no publishable records in $dir — attestation upstream produced nothing" >&2
+    return 1
+  fi
   for f in "${files[@]}"; do
     local file content_type
     file=$(basename "$f")

--- a/tools/audit/aliens_manifest_audit.sh
+++ b/tools/audit/aliens_manifest_audit.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 # tools/audit/aliens_manifest_audit.sh
 #
-# /pursue manifest re-hash audit. Picks the smallest record, verifies
-# size + sha256 against what the manifest claims.
+# /pursue manifest re-hash audit.
+#
+# Reworked 2026-07-25 for the free-tier posture. The old version sampled the
+# smallest DOCUMENT and required it to be fetchable — true only while R2 was
+# mirroring 10.5 GB of PDFs. Document bytes are now deliberately withheld (CF
+# ToS §2.8 on a Free zone; war.gov 403s us, so there is no upstream to
+# redirect to either), which made this audit exit FATAL every day on a policy
+# rather than a fault.
+#
+# The invariant that still earns its keep is the one the archive rests on:
+# NOTHING IS SERVED THAT FAILS ITS OWN ATTESTATION. So this samples what we do
+# serve — the digest-verified thumbnails — and re-hashes them against the
+# manifest. Withheld is expected and never a failure; drift on a served
+# artifact is.
 #
 # See docs/plans/ALIENS_MANIFEST_AUDIT.md.
 #
@@ -23,6 +35,7 @@ done
 BASE="${LEDATIC_BASE:-https://ledatic.org}"
 MANIFEST_PATH="${MANIFEST_PATH:-/pursue/manifest.jsonl}"
 MANIFEST=/tmp/aliens_manifest.jsonl
+SAMPLE_N="${SAMPLE_N:-3}"
 
 log()    { (( QUIET )) || echo "  $*"; }
 header() { (( QUIET )) || echo "--- $* ---"; }
@@ -36,87 +49,109 @@ records=$(wc -l <"$MANIFEST" | tr -d ' ')
 (( QUIET )) || echo "manifest: $BASE$MANIFEST_PATH ($records records)"
 (( QUIET )) || echo
 
-# ---- 2. Pick smallest record --------------------------------------------
+# ---- 2. Candidate served artifacts (thumbnails, smallest first) ----------
+# A thumbnail path is published only when every record citing it agrees on one
+# digest, so sampling by path is well-defined. Smallest-first keeps the audit
+# cheap and deterministic. Serial fetches on purpose: hammering our own CDN in
+# parallel trips bot protection, and then you are hashing a challenge page.
 header "sample selection"
-# Extract size_bytes + local_path + sha256 per line; tolerate whitespace.
-# Find smallest by size. One line per JSON record.
-sample=$(while IFS= read -r line; do
-  s=$(echo "$line" | grep -oE '"size_bytes"[[:space:]]*:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' | head -1)
-  p=$(echo "$line" | grep -oE '"local_path"[[:space:]]*:[[:space:]]*"[^"]+"' | sed 's/.*"local_path"[[:space:]]*:[[:space:]]*"//;s/"$//' | head -1)
-  # First sha256 in record is the main file's (thumbnail_sha256 comes later)
-  h=$(echo "$line" | grep -oE '"sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]+"' | head -1 | grep -oE '[0-9a-f]{64}')
-  [[ -n "$s" && -n "$p" && -n "$h" ]] && printf '%s\t%s\t%s\n' "$s" "$p" "$h"
-done <"$MANIFEST" | sort -n | head -1)
-size_claimed=$(echo "$sample" | cut -f1)
-local_path=$(echo "$sample" | cut -f2)
-sha_claimed=$(echo "$sample" | cut -f3)
-log "smallest record: $local_path"
-log "claimed size: $size_claimed bytes"
-log "claimed sha256: ${sha_claimed:0:16}..."
+candidates=$(python3 - "$MANIFEST" "$SAMPLE_N" <<'PY'
+import json, sys, collections
+path, n = sys.argv[1], int(sys.argv[2])
+recs = [json.loads(l) for l in open(path) if l.strip()]
+digests = collections.defaultdict(set)
+for r in recs:
+    t = r.get("thumbnail_local")
+    if t:
+        digests[t].add(r.get("thumbnail_sha256"))
+rows = {}
+for r in recs:
+    t = r.get("thumbnail_local")
+    if not t or len(digests[t]) != 1:
+        continue                      # ambiguous path — correctly withheld
+    rows[t] = (r.get("thumbnail_size_bytes") or 0, t, r.get("thumbnail_sha256"))
+for size, t, sha in sorted(rows.values())[:n]:
+    print(f"{size}\t{t}\t{sha}")
+PY
+)
+[[ -n "$candidates" ]] || { echo "FATAL: no unambiguous thumbnail records in manifest"; exit 2; }
 
-if [[ -z "$size_claimed" || -z "$local_path" || -z "$sha_claimed" ]]; then
-  echo "FATAL: could not parse manifest fields"
-  exit 2
-fi
+# ---- 3. Verify each served candidate ------------------------------------
+fail=0; served=0; withheld=0
+while IFS=$'\t' read -r size_claimed local_path sha_claimed; do
+  [[ -n "$local_path" ]] || continue
+  rel=${local_path#files/}
+  encoded=$(python3 -c "import sys,urllib.parse;print('/'.join(urllib.parse.quote(p) for p in sys.argv[1].split('/')))" "$rel")
+  url="$BASE/pursue/files/$encoded"
+  tmp=/tmp/aliens_audit_sample.bin
+  rm -f "$tmp"
+  if ! curl -sf --max-time 40 "$url" -o "$tmp"; then
+    withheld=$((withheld + 1))
+    log "withheld (expected, not a failure): $rel"
+    continue
+  fi
+  served=$((served + 1))
+  size_actual=$(wc -c <"$tmp" | tr -d ' ')
+  sha_actual=$(shasum -a 256 "$tmp" | awk '{print $1}')
+  if [[ "$size_actual" != "$size_claimed" ]]; then
+    log "FAIL: size drift on $rel ($size_claimed claimed vs $size_actual actual)"
+    fail=1
+  elif [[ "$sha_actual" != "$sha_claimed" ]]; then
+    log "FAIL: sha256 drift on $rel"
+    log "  claimed: $sha_claimed"
+    log "  actual:  $sha_actual"
+    fail=1
+  else
+    log "ok  $rel  (${size_actual} B, ${sha_actual:0:16}…)"
+  fi
+  rm -f "$tmp"
+done <<<"$candidates"
 
-# ---- 3. HEAD: size check ------------------------------------------------
-header "size check"
-# URL-encode path segments (R2 keys with spaces, etc.)
-encoded_path=$(python3 -c "import sys, urllib.parse; print('/'.join(urllib.parse.quote(p) for p in sys.argv[1].split('/')))" "$local_path")
-url="$BASE/pursue/$encoded_path"
-size_actual=$(curl -sfI "$url" | grep -i '^content-length:' | awk '{print $2}' | tr -d '\r')
-log "url: $url"
-log "actual size: $size_actual bytes"
-
-fail=0
-if [[ "$size_actual" != "$size_claimed" ]]; then
-  log "FAIL: size drift ($size_claimed claimed vs $size_actual actual)"
+# A served set of zero means thumbnail publication silently lapsed — the
+# archive would render as placeholders and nobody would notice.
+if (( served == 0 )); then
+  log "FAIL: no sampled thumbnail was served — publication may have lapsed"
   fail=1
 fi
 
-# ---- 4. GET: sha256 check -----------------------------------------------
-header "sha256 check"
-tmp=/tmp/aliens_audit_sample.bin
-rm -f "$tmp"
-curl -sf "$url" -o "$tmp" || { echo "FATAL: GET failed for $url"; exit 2; }
-sha_actual=$(shasum -a 256 "$tmp" | awk '{print $1}')
-log "actual sha256: ${sha_actual:0:16}..."
-
-if [[ "$sha_actual" != "$sha_claimed" ]]; then
-  log "FAIL: sha256 drift"
-  log "  claimed: $sha_claimed"
-  log "  actual:  $sha_actual"
-  fail=1
+# ---- 4. Policy check: document bytes stay withheld -----------------------
+header "document withholding"
+doc=$(python3 - "$MANIFEST" <<'PY'
+import json, sys
+recs = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+recs = [r for r in recs if r.get("local_path")]
+r = min(recs, key=lambda r: r.get("size_bytes") or 0)
+print(r["local_path"][len("files/"):])
+PY
+)
+doc_enc=$(python3 -c "import sys,urllib.parse;print('/'.join(urllib.parse.quote(p) for p in sys.argv[1].split('/')))" "$doc")
+doc_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$BASE/pursue/files/$doc_enc")
+if [[ "$doc_code" == "404" ]]; then
+  log "ok  documents withheld as intended (sampled → 404)"
+else
+  log "NOTE: document bytes are being served again (sampled → $doc_code)"
+  log "      not a failure — but re-check the ToS §2.8 exposure decision"
 fi
-rm -f "$tmp"
 
 # ---- 5. Verdict ----------------------------------------------------------
 echo
 echo "=== SUMMARY ==="
-echo "sampled: $local_path"
+echo "sampled=$((served + withheld)) served=$served withheld=$withheld doc_probe=$doc_code"
 
 if (( LAB_MODE == 1 )); then
-  size_match=$([[ "$size_actual" == "$size_claimed" ]] && echo 1 || echo 0)
-  sha_match=$([[ "$sha_actual" == "$sha_claimed" ]] && echo 1 || echo 0)
   echo "===RAIL_LAB_COUNTERS==="
-  echo "{\"counter\": \"size_match\", \"value\": $size_match}"
-  echo "{\"counter\": \"sha_match\", \"value\": $sha_match}"
-  echo "{\"counter\": \"sampled_size_bytes\", \"value\": ${size_claimed:-0}}"
+  echo "{\"counter\": \"served_verified\", \"value\": $served}"
+  echo "{\"counter\": \"served_drifted\", \"value\": $fail}"
   echo "{\"counter\": \"manifest_records\", \"value\": ${records:-0}}"
   echo "===END==="
-  if (( fail == 0 )); then
-    echo "===VERDICT=== PASS"
-    exit 0
-  else
-    echo "===VERDICT=== FALSIFIED"
-    exit 0  # exit 0 in --lab mode: runner succeeded, verdict is the falsification claim
-  fi
+  if (( fail == 0 )); then echo "===VERDICT=== PASS"; else echo "===VERDICT=== FALSIFIED"; fi
+  exit 0
 fi
 
 if (( fail == 0 )); then
-  echo "VERDICT=PASS — sampled record matches manifest (size + sha256)"
+  echo "VERDICT=PASS — every served artifact matches its attestation"
   exit 0
 else
-  echo "VERDICT=FALSIFIED — drift detected on $local_path"
+  echo "VERDICT=FALSIFIED — a served artifact drifted from the manifest"
   exit 1
 fi

--- a/tools/audit/attest_endpoint_walk.sh
+++ b/tools/audit/attest_endpoint_walk.sh
@@ -4,8 +4,8 @@
 # Endpoint audit walker — Phase 1 of docs/plans/ATTEST_ENDPOINT_AUDIT.md.
 # Probes each public attestation surface, reports per-class verdict + counters.
 #
-# READ-ONLY. No healing. No chain write yet (Phase 2 — gated on a planned
-# internal lab-entry route).
+# READ-ONLY. No healing. No chain write yet (Phase 2 — gated on Studio :9101
+# /lab/entry route from the lab integration plan).
 #
 # Exit code: 0 if every class PASS, 1 if any class FAIL, 2 on probe error.
 #
@@ -111,6 +111,55 @@ class_witness() {
 }
 
 # ============================================================================
+# CLASS: frame_attest — frame side-car fresh (pulse-lag age) + digest coherent
+# ============================================================================
+# Added 2026-06-09: the frame publisher was dead 2026-05-28..06-09 and nothing
+# alarmed, because no walker checked the side-car's age. Age axis is pulse-lag,
+# not wall-clock — the side-car carries no timestamp, and pulse_id is the house
+# clock anyway.
+#
+# Threshold recalibrated 2026-07-26: 20 -> 90. The original assumed the beacon
+# ticked ~30s/pulse, so a 30s publisher was ~1 pulse behind. The beacon now runs
+# at ~1.15s/pulse (measured: 26 pulses in 30s), so a publisher ticking every 32s
+# is ~28 pulses behind BY CONSTRUCTION — permanently past a threshold of 20. The
+# class was failing on a completely healthy publisher. 90 pulses ~= 100s ~= three
+# publisher intervals: still catches a genuinely dead publisher inside two
+# minutes, without alarming on the baseline. If the beacon cadence changes again,
+# this number has to move with it.
+class_frame_attest() {
+  local payload att_pulse cur_pulse frame_sha wit_sha lag
+  payload=$(curl -sf "$BASE/entropy/frame/latest.attestation.json")
+  if [[ -z "$payload" ]]; then
+    log "FAIL: latest.attestation.json unreachable"
+    verdict frame_attest FAIL; return
+  fi
+  # Publisher emits python-default JSON ('": "' separators) — json_int/json_str
+  # are compact-only, so extract space-tolerantly here.
+  att_pulse=$(grep -oE '"pulse_id"[[:space:]]*:[[:space:]]*[0-9]+' <<<"$payload" | grep -oE '[0-9]+$' | head -1)
+  frame_sha=$(grep -oE '"sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]{64}"' <<<"$payload" | grep -oE '[0-9a-f]{64}' | head -1)
+  wit_sha=$(grep -oE '"digest_sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]{64}"' <<<"$payload" | grep -oE '[0-9a-f]{64}' | head -1)
+  cur_pulse=$(json_int "$(curl -sf "$BASE/entropy/pulse")" pulse_id)
+  if [[ -z "$att_pulse" || -z "$cur_pulse" || -z "$frame_sha" ]]; then
+    log "FAIL: missing fields (att_pulse=$att_pulse cur_pulse=$cur_pulse sha=${frame_sha:0:8})"
+    verdict frame_attest FAIL; return
+  fi
+  lag=$(( cur_pulse - att_pulse ))
+  log "attestation pulse=$att_pulse current=$cur_pulse lag=${lag} pulses; sha=${frame_sha:0:12}"
+  if (( lag < 0 )); then
+    log "FAIL: attestation pulse ahead of beacon ($att_pulse > $cur_pulse)"
+    verdict frame_attest FAIL
+  elif (( lag > 90 )); then
+    log "FAIL: frame attestation stale (lag=${lag} pulses > 90 ~= publisher dead)"
+    verdict frame_attest FAIL
+  elif [[ -n "$wit_sha" && "$wit_sha" != "$frame_sha" ]]; then
+    log "FAIL: witness digest ($wit_sha) != frame sha ($frame_sha)"
+    verdict frame_attest FAIL
+  else
+    verdict frame_attest PASS
+  fi
+}
+
+# ============================================================================
 # CLASS: fleet — status.json fresh AND pi-alive matches our own probe
 # ============================================================================
 class_fleet() {
@@ -132,8 +181,14 @@ for n in d.get('nodes', []):
         break
 " 2>/dev/null)
   log "status age: ${age}s; pi: ${pi_alive_pub}"
-  if (( age > 300 )); then
-    log "FAIL: status stale (${age}s > 300s)"; verdict fleet FAIL; return
+  # Threshold raised 300 → 900 on 2026-07-25. The free-tier pivot (2026-07-24)
+  # throttles the fleet-status KV write to once per 600s to stay inside the
+  # 1k/day free write cap, so the published record is now legitimately up to
+  # ~600s old. The old 300s bound described the pre-throttle write cadence and
+  # had become a guaranteed daily false alarm. 900s = throttle + one missed
+  # tick, so a genuinely wedged publisher still trips it.
+  if (( age > 900 )); then
+    log "FAIL: status stale (${age}s > 900s)"; verdict fleet FAIL; return
   fi
   token=$(cat ~/.fleet/token 2>/dev/null || true)
   if [[ -z "$token" ]]; then
@@ -283,21 +338,31 @@ class_releases() {
 }
 
 # ============================================================================
-# CLASS: dda — index reachable + well-formed JSON
+# CLASS: dda — engagement CLOSURE holds (closed + paid 2026-05-12)
+#
+# Reworked 2026-07-25. The old check asserted /dda/index.json was reachable
+# and well-formed — true only while the engagement was live. It had been
+# FAILING every day since the rollup went dark, which is alert fatigue on a
+# route that is correctly retired.
+#
+# The assertion that still earns its keep is the inverse: a closed client
+# surface must STAY closed. 410 Gone = pass. Serving content again is the
+# real regression — that would mean client material leaked back onto a
+# public surface after closeout.
 # ============================================================================
 class_dda() {
-  local idx
-  idx=$(curl -sf "$BASE/dda/index.json")
-  if [[ -z "$idx" ]]; then
-    log "FAIL: dda/index.json unreachable"
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/dda/index.json")
+  if [[ "$code" == "410" ]]; then
+    log "closure holds: dda/index.json → 410 Gone"
+    verdict dda PASS; return
+  fi
+  if [[ "$code" == "200" ]]; then
+    log "FAIL: dda/index.json serving 200 — closed engagement is public again"
     verdict dda FAIL; return
   fi
-  if grep -q '"kind"' <<<"$idx" || grep -q '"version"' <<<"$idx"; then
-    verdict dda PASS
-  else
-    log "FAIL: dda/index.json malformed (no kind/version)"
-    verdict dda FAIL
-  fi
+  log "FAIL: dda/index.json → $code (expected 410 Gone for a closed engagement)"
+  verdict dda FAIL
 }
 
 # ============================================================================
@@ -309,6 +374,7 @@ class_dda() {
 
 header beacon;          class_beacon
 header witness;         class_witness
+header frame_attest;    class_frame_attest
 header fleet;           class_fleet
 header builds_badge;    class_builds_badge
 header selfhost_badge;  class_selfhost_badge

--- a/tools/plasma/mhd_server.py
+++ b/tools/plasma/mhd_server.py
@@ -7,6 +7,12 @@ Serves:
   /frame               → latest GPU frame (binary, ~100KB)
   /control  (POST)     → write control JSON to /tmp/plasma_ctrl.json
   /live                → thruster_live.html (GPU-connected client)
+  /verify              → verify.html (byte-exact chamber audit page)
+  /attest              → JSON attestation for the latest frame: snapshot
+                         the planes, render the chamber with the native
+                         chamber_cli, publish sha256 of both
+  /attest/planes32.bin?fid=N  → the attested planes bytes (393216 B)
+  /attest/chamber.bin?fid=N   → the attested chamber render (49152 B)
 
 The Metal host (mhd_live) writes frames to /tmp/plasma_live.bin.
 This server reads that file and serves it to any connected browser.
@@ -16,10 +22,12 @@ Usage:
   python3 mhd_server.py 9300               # custom port
 """
 
+import hashlib
 import http.server
 import json
 import os
 import struct
+import subprocess
 import sys
 import time
 
@@ -28,8 +36,20 @@ FRAME_PATH = "/tmp/plasma_live.bin"
 CTRL_PATH = "/tmp/plasma_ctrl.json"
 STATIC_DIR = os.path.dirname(os.path.abspath(__file__))
 
+# ── attest path (byte-exact chamber audit) ──────────────────────────
+ATTEST_DIR = "/tmp/plasma_attest"
+CHAMBER_CLI = os.path.join(STATIC_DIR, "chamber_cli")
+WASM_PATH = os.path.join(STATIC_DIR, "chamber_verify.wasm")
+PLANES_OFF = 48          # header 16 B + metrics 32 B
+PLANES_LEN = 6 * 128 * 128 * 4   # 393216 — f32 LE, plane-major
+CHAMBER_LEN = 128 * 128 * 3      # 49152 — RGB8
+
 # Cache the last frame to avoid re-reading unchanged files
 _frame_cache = (0, b"")  # (mtime, data)
+
+# Last attestation: {frame_id: response_dict}.  One entry only — the
+# byte files for that frame_id live in ATTEST_DIR.
+_attest_cache = {}
 
 
 def read_frame():
@@ -46,9 +66,119 @@ def read_frame():
         return b""
 
 
+def make_attest():
+    """Snapshot the live frame, render it with the native CLI, hash both.
+
+    Returns (http_status, response_dict).  Idempotent per frame_id: the
+    same frame_id always maps to the same planes bytes (they were
+    snapshotted once), so the hashes are stable across repeated calls.
+    """
+    global _attest_cache
+    data = read_frame()
+    if len(data) < PLANES_OFF + PLANES_LEN:
+        return 503, {"error": "no live frame (mhd_live not writing?)",
+                     "have_bytes": len(data)}
+    n1, n2, nfields, frame_id = struct.unpack_from("<4I", data, 0)
+    if n1 != 128 or n2 != 128 or nfields != 6:
+        return 503, {"error": f"unexpected frame header {n1}x{n2}x{nfields}"}
+    if frame_id in _attest_cache:
+        return 200, _attest_cache[frame_id]
+
+    metrics = struct.unpack_from("<8f", data, 16)
+    sim_time = metrics[5]
+    planes = data[PLANES_OFF:PLANES_OFF + PLANES_LEN]
+
+    os.makedirs(ATTEST_DIR, exist_ok=True)
+    planes_path = os.path.join(ATTEST_DIR, f"planes32_{frame_id}.bin")
+    chamber_path = os.path.join(ATTEST_DIR, f"chamber_{frame_id}.bin")
+    with open(planes_path, "wb") as f:
+        f.write(planes)
+
+    try:
+        r = subprocess.run([CHAMBER_CLI, planes_path, chamber_path],
+                           capture_output=True, timeout=15)
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return 500, {"error": f"chamber_cli failed: {e}"}
+    if r.returncode != 0:
+        return 500, {"error": "chamber_cli nonzero exit",
+                     "stdout": r.stdout.decode(errors="replace")[:200]}
+    with open(chamber_path, "rb") as f:
+        chamber = f.read()
+    if len(chamber) != CHAMBER_LEN:
+        return 500, {"error": f"chamber render is {len(chamber)} B, want {CHAMBER_LEN}"}
+
+    try:
+        with open(WASM_PATH, "rb") as f:
+            wasm_sha = hashlib.sha256(f.read()).hexdigest()
+    except FileNotFoundError:
+        wasm_sha = None
+
+    resp = {
+        "frame_id": frame_id,
+        "sim_time": round(sim_time, 6),
+        "planes_sha256": hashlib.sha256(planes).hexdigest(),
+        "chamber_sha256": hashlib.sha256(chamber).hexdigest(),
+        "n_bytes": CHAMBER_LEN,
+        "planes_bytes": PLANES_LEN,
+        "planes_url": f"/attest/planes32.bin?fid={frame_id}",
+        "chamber_url": f"/attest/chamber.bin?fid={frame_id}",
+        "wasm_url": "/chamber_verify.wasm",
+        "wasm_sha256": wasm_sha,
+        "widen_rule": "each f32 (LE, plane-major rho,vx,vy,p,Bx,By) widened to f64 — exact",
+        "narrow_rule": "clamp [0.0, 255.0], truncate toward zero",
+    }
+
+    # Evict the previous attestation's byte files (keep /tmp tidy).
+    for old_fid in list(_attest_cache):
+        if old_fid != frame_id:
+            for stem in (f"planes32_{old_fid}.bin", f"chamber_{old_fid}.bin"):
+                try:
+                    os.remove(os.path.join(ATTEST_DIR, stem))
+                except FileNotFoundError:
+                    pass
+    _attest_cache = {frame_id: resp}
+    return 200, resp
+
+
 class PlasmaHandler(http.server.SimpleHTTPRequestHandler):
+    # .wasm must arrive as application/wasm or the browser refuses
+    # WebAssembly.instantiateStreaming.
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=STATIC_DIR, **kwargs)
+
+    def send_bytes(self, status, body, ctype):
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def serve_attest_file(self, stem):
+        # /attest/<stem>.bin?fid=N → the snapshotted bytes for frame N.
+        query = self.path.split("?", 1)[1] if "?" in self.path else ""
+        fid = None
+        for part in query.split("&"):
+            if part.startswith("fid="):
+                fid = part[4:]
+        if fid is None or not fid.isdigit():
+            self.send_bytes(400, b'{"error": "missing ?fid="}', "application/json")
+            return
+        path = os.path.join(ATTEST_DIR, f"{stem}_{int(fid)}.bin")
+        try:
+            with open(path, "rb") as f:
+                body = f.read()
+        except FileNotFoundError:
+            self.send_bytes(404, b'{"error": "attestation expired; re-fetch /attest"}',
+                            "application/json")
+            return
+        self.send_bytes(200, body, "application/octet-stream")
 
     def do_GET(self):
         if self.path == "/frame":
@@ -72,6 +202,16 @@ class PlasmaHandler(http.server.SimpleHTTPRequestHandler):
         elif self.path == "/live":
             self.path = "/thruster_live.html"
             super().do_GET()
+        elif self.path == "/verify":
+            self.path = "/verify.html"
+            super().do_GET()
+        elif self.path == "/attest":
+            status, resp = make_attest()
+            self.send_bytes(status, json.dumps(resp).encode(), "application/json")
+        elif self.path.startswith("/attest/planes32.bin"):
+            self.serve_attest_file("planes32")
+        elif self.path.startswith("/attest/chamber.bin"):
+            self.serve_attest_file("chamber")
         elif self.path == "/status":
             # Check if mhd_live is running
             exists = os.path.exists(FRAME_PATH)
@@ -128,5 +268,6 @@ if __name__ == "__main__":
     print(f"  GPU frames:   {FRAME_PATH}")
     print(f"  Control:      POST {CTRL_PATH}")
     print(f"  Live view:    http://localhost:{PORT}/live")
+    print(f"  Audit:        http://localhost:{PORT}/verify")
     print()
     server.serve_forever()

--- a/tools/railml/self_improve.rail
+++ b/tools/railml/self_improve.rail
@@ -767,10 +767,14 @@ run_batch model_dir tasks round level pass fail harvested =
     let desc = task_desc task_line
     let expected = task_expected task_line
     let _ = print (cat ["\n  -> ", desc, if expected == "" then "" else cat [" [expect: ", expected, "]"]])
-    -- Reset arena to prevent accumulation across tasks
+    -- Bound per-task arena growth. The reset MUST come after the last use of
+    -- `code`/`result`: try_task allocates both ABOVE this mark, so resetting
+    -- first left them dangling — the old code then read `result`, scored
+    -- `code`, and wrote `code` to disk through freed memory. `desc`/`expected`
+    -- are allocated before the mark and survive; `score`/`n`/`pass`/`fail` are
+    -- tagged-int immediates, so arithmetic after the reset is safe.
     let m = arena_mark 0
     let (code, result) = try_task model_dir desc expected
-    let _ = arena_reset m
     if result == "success" then
       let _ = print "    PASS"
       -- Score the generation
@@ -778,9 +782,11 @@ run_batch model_dir tasks round level pass fail harvested =
       let _ = log_quality round level desc score
       -- Harvest the successful code
       let n = append_harvest desc code
+      let _ = arena_reset m
       run_batch model_dir (tail tasks) round level (pass + 1) fail (harvested + n)
     else
       let _ = print (cat ["    FAIL (", result, ")"])
+      let _ = arena_reset m
       run_batch model_dir (tail tasks) round level pass (fail + 1) harvested
 
 -- ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
The working clone's audit/attest/plasma/railml scripts ran uncommitted for weeks while the hourly drift audit executed them. This lands the running versions on master: attest selfhost/test-run/publish hardening, aliens-manifest + attest-endpoint audit walkers, mhd_server additions, self_improve tweaks. Also accepts master's deletion of tools/bitexact/lm2_attested_train.rail (modified copy salvaged to the cleanout archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)