### PR TITLE
tools: point speak + labrat at the live Studio server (Qwen3.8-27B, :8092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Rail are documented here.
 ## Unreleased
 
 ### Fixed
+- **speak + labrat repointed at the live Studio server** (Qwen3.8-27B on
+  `:8092`): both tools pinned the retired Qwen3.5-Opus-distill id — and
+  labrat a dead `:8080` — which would have dragged a second 27B onto the
+  Studio GPU the moment either ran (the mlx server loads any model a
+  request names).
 - **`is_float` local-shadowing guard** (the 811d7f2 delta): the V-case's
   global `__float_ret_<name>` consult (added 4f689b7) ran unconditionally,
   so a local int shadowing a float-returning global was typed float and

--- a/tools/apps/speak.rail
+++ b/tools/apps/speak.rail
@@ -13,7 +13,7 @@ json_esc_nl s = join "\\n" (split "\n" s)
 
 llm system_prompt user_prompt =
   let body = cat [
-    "{", q, "model", q, ":", q, "mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit", q, ",", q, "messages", q, ":[",
+    "{", q, "model", q, ":", q, "lmstudio-community/Qwen3.8-27B-MLX-6bit", q, ",", q, "messages", q, ":[",
     "{", q, "role", q, ":", q, "system", q, ",", q, "content", q, ":", q, json_esc (json_esc_nl system_prompt), q, "},",
     "{", q, "role", q, ":", q, "user", q, ",", q, "content", q, ":", q, json_esc (json_esc_nl user_prompt), q, "}",
     "],", q, "max_tokens", q, ":1024,", q, "temperature", q, ":0.0}"]

--- a/tools/labrat/README.md
+++ b/tools/labrat/README.md
@@ -51,7 +51,7 @@ shell-out side effects.
 ## Known constraints (Rail-specific)
 
 - `stdlib/llm.rail` / `stdlib/mlx_client.rail` handle the LLM call. MLX
-  on `:8080` serves `Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-6bit` —
+  on `:8092` serves `Qwen3.8-27B-MLX-6bit` —
   adequate for this task class (the paper equivalent used Claude).
 - Concurrent Metal kernel work contends with live training; gate via a
   sentinel file or explicit queue.

--- a/tools/labrat/labrat.rail
+++ b/tools/labrat/labrat.rail
@@ -30,7 +30,7 @@ import "stdlib/list.rail"
 labrat_max_iters = 5
 labrat_bench_gate_ratio = 1.6
 labrat_correctness_tol = 0.001
-labrat_mlx_port = "8080"
+labrat_mlx_port = "8092"
 
 -- ──────────────────────────────────────────────────────────────────────────────
 -- LOCAL HELPERS (parsers + string utils). Prefix `lb_` to avoid name collisions.


### PR DESCRIPTION
Both tools pinned the retired `mlx-community/Qwen3.5-27B-Claude-4.6-Opus-Distilled-MLX-4bit`; labrat additionally pinned `:8080`, which no longer serves. The Studio's mlx server loads any model a request names, so either tool running would have pulled a second 27B onto the GPU next to the promoted Qwen3.8 (memory: the two-models-on-GPU trap). One-string swaps, no logic changes. CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzjMXh1wxgasCH81MJfTCk