### PR TITLE
Attest the reproducible self-compile, not the as/ld fallback

### DIFF
--- a/tools/attest/attest_selfhost.sh
+++ b/tools/attest/attest_selfhost.sh
@@ -40,13 +40,30 @@ src_sha=$(shasum -a 256 "$src"   | awk '{print $1}')
 pulse_start=$(get_pulse)
 echo "selfhost: commit=$short seed=${seed_sha:0:16} pulse_start=$pulse_start"
 
-echo "  pass 1 ..."
-./"$bin" self >"$dest/pass1.log" 2>&1
+# Attest the reproducible path, not the fallback. verify_reproducible.sh says
+# it outright: RAIL_ARENA_MB below 5000 "selects the as/ld fallback (not
+# bit-reproducible)". This script had no arena set, so it ran at the 1GB
+# default and was certifying a fixed point in the mode the project's own
+# verifier documents as not bit-reproducible. It read green because the seed
+# it happened to be handed also converged there; the committed seed is built
+# at 6000, and at 6000 it reproduces itself exactly.
+#
+# Same value and same default as verify_reproducible.sh and the nightly repro
+# witness, so all three checkers now attest the same thing.
+ARENA="${RAIL_ARENA_MB:-6000}"
+if [ "$ARENA" -lt 5000 ]; then
+  echo "selfhost: RAIL_ARENA_MB=$ARENA < 5000 is the as/ld fallback, which is not" >&2
+  echo "selfhost: bit-reproducible. Refusing to attest a fixed point from it." >&2
+  exit 2
+fi
+
+echo "  pass 1 ... (arena=${ARENA}MB)"
+RAIL_ARENA_MB="$ARENA" ./"$bin" self >"$dest/pass1.log" 2>&1
 mv /tmp/rail_self "$dest/rail_self_1"
 pass1_sha=$(shasum -a 256 "$dest/rail_self_1" | awk '{print $1}')
 
 echo "  pass 2 ..."
-./"$dest/rail_self_1" self >"$dest/pass2.log" 2>&1
+RAIL_ARENA_MB="$ARENA" ./"$dest/rail_self_1" self >"$dest/pass2.log" 2>&1
 mv /tmp/rail_self "$dest/rail_self_2"
 pass2_sha=$(shasum -a 256 "$dest/rail_self_2" | awk '{print $1}')
 


### PR DESCRIPTION
`attest_selfhost.sh` set no arena, so it ran `self` at the 1GB default. `verify_reproducible.sh` says what that mode is, in its own words:

> `RAIL_ARENA_MB=$ARENA < 5000` selects the as/ld fallback (**not bit-reproducible**).

So the daily job has been certifying a fixed point in the one mode our own verifier documents as not reproducible, and publishing `fixed_point: true` from it.

Tonight it published `fixed_point: false`. That is the design working. The seed committed in #59 is built at 6000 per the recipe in CLAUDE.md and reproduces itself exactly there; at the 1GB default it emits a different binary. Both are deterministic:

```
arena 6000:     b92372961d48b226   b92372961d48b226     (== committed seed)
default 1GB:    c2b06488000f81fd   c2b06488000f81fd
```

Not a broken compiler. The wrong arena.

This defaults `attest_selfhost.sh` to 6000, matching `verify_reproducible.sh` and the nightly repro witness so all three checkers attest the same thing, and makes it refuse below 5000 rather than quietly attesting the fallback.

Verified after the change: `FIXED POINT: pass1 == pass2 == b92372961d48b226`, `seed_match: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)