### PR TITLE
verify: a verifier that prints ok then dies is not a pass; the umbrella checks itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ All notable changes to Rail are documented here.
   rather than re-signed. `VERIFY.md` and `README.md` now say the seed links
   `libSystem` and that `gpu_map` needs a Metal device.
 
+- **`check.sh` section 5 read the Rail verifier's verdict through a pipe and
+  lost its exit status**, so a verifier that printed `ok` and then died
+  (exit 139) still passed the umbrella 5/5 (found by the same outside
+  reviewer, 2026-09-07). The verdict line and the exit status are now
+  captured separately and both must agree, in `check.sh` and in
+  `verify_selftest.sh`. New `tools/verify/check_selftest.sh` runs the
+  umbrella against a stub `rail_native` three ways (well-behaved, test
+  process exit 139, verifier ok-then-139) and `check.sh` section 7 runs it.
 - **`run_test` compared only the FIRST line of a test program's output.**
   `trim` ran before the stdout/exit split, so a crash (exit 139), a nonzero
   status, and any extra line after a matching first line were all invisible,

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -76,6 +76,7 @@ re-verify it. Regenerate and commit it whenever the compiler or the seed changes
 
 ```bash
 tools/attest/verify_selftest.sh        # positive control + a replacement artifact both verifiers must reject
+tools/verify/check_selftest.sh         # the umbrella itself must fail on a crashed test run or an ok-then-crash verifier
 git show 28ad78be16259b7c9af48bbf3e2a06810aa6491e:tools/compile.rail > /tmp/v530_compile.rail
 ./rail_native run tools/attest/verify.rail /tmp/v530_compile.rail releases/v5.3.0/compile.rail.attestation.json
 ```
@@ -84,8 +85,8 @@ Tagged releases are Ed25519-signed and anchored to a public entropy beacon; the
 verifier is itself Rail (`tools/attest/verify.rail`), and `check.sh` runs it
 against the newest `releases/v*/index.json`. The witness public key is fetched
 from `https://ledatic.org/attest/fleet0.pub.pem` on first use; that fetch trusts
-the site's TLS, nothing more. A verifier passes only when the file's digest
-equals the digest inside the signed witness; the unsigned `artifact.sha256`
+the site's TLS, nothing more. A verifier passes only when it exits 0 AND
+prints `ok`, and the file's digest equals the digest inside the signed witness; the unsigned `artifact.sha256`
 field in the sidecar must agree with both (until 2026-09-06 the shell verifier
 compared only the unsigned field, see `verify_selftest.sh`).
 

--- a/tools/attest/verify_selftest.sh
+++ b/tools/attest/verify_selftest.sh
@@ -35,9 +35,13 @@ a["artifact"]["sha256"] = sys.argv[3]          # unsigned field only; witness un
 json.dump(a, open(sys.argv[2], "w"), indent=2)
 PY
 
-rail_verify() {  # <input> <attestation> -> prints the verdict line; its own exit is not the signal
-  RAIL_ARENA_MB="${RAIL_ARENA_MB:-2000}" ./rail_native --out-prefix "$tmp/rv" run tools/attest/verify.rail "$1" "$2" "$pub" > "$tmp/rv.log" 2>&1
-  grep -E '^(ok|BAD)' "$tmp/rv.log"
+rail_verify() {  # <input> <attestation> <want: ok|BAD> -> 0 iff the verdict line AND the exit status agree with want
+  RAIL_ARENA_MB="${RAIL_ARENA_MB:-2000}" ./rail_native --out-prefix "$tmp/rv" run tools/attest/verify.rail "$1" "$2" "$pub" > "$tmp/rv.log" 2>&1; rc=$?
+  v=$(grep -E '^(ok|BAD)' "$tmp/rv.log" | tail -1)
+  case "$3" in
+    ok)  [ "$rc" = 0 ] && [ "${v#ok}" != "$v" ];;
+    BAD) [ "$rc" != 0 ] && [ "${v#BAD}" != "$v" ];;
+  esac
 }
 
 fail=0
@@ -48,7 +52,7 @@ expect() {  # <label> <want: 0|nonzero> <got>
 }
 
 tools/attest/verify.sh "$ctl_in" "$ctl_att" "$pub" >/dev/null 2>&1; expect "shell verifier accepts the control" 0 $?
-rail_verify "$ctl_in" "$ctl_att" | grep -q '^ok'; expect "Rail verifier accepts the control" 0 $?
+rail_verify "$ctl_in" "$ctl_att" ok; expect "Rail verifier accepts the control (ok + exit 0)" 0 $?
 tools/attest/verify.sh "$tmp/replacement.json" "$tmp/tampered.attestation.json" "$pub" >/dev/null 2>&1; expect "shell verifier rejects a replacement artifact" nonzero $?
-rail_verify "$tmp/replacement.json" "$tmp/tampered.attestation.json" | grep -q '^BAD'; expect "Rail verifier rejects a replacement artifact" 0 $?
+rail_verify "$tmp/replacement.json" "$tmp/tampered.attestation.json" BAD; expect "Rail verifier rejects a replacement artifact (BAD + nonzero exit)" 0 $?
 exit $fail

--- a/tools/verify/check.sh
+++ b/tools/verify/check.sh
@@ -62,15 +62,24 @@ else
     no "$tag: no witness pubkey at $PUB (set RAIL_WITNESS_PUB or fetch https://ledatic.org/attest/fleet0.pub.pem)"
   else
     git show "$commit:tools/compile.rail" > "$tmp/compile.rail"
-    v=$(RAIL_ARENA_MB=2000 ./rail_native --out-prefix "$tmp/verify" run tools/attest/verify.rail \
-          "$tmp/compile.rail" "$idx/compile.rail.attestation.json" "$PUB" 2>&1 | grep -E '^(ok|BAD)' | tail -1)
-    case "$v" in ok*) ok "$tag compile.rail @ ${commit:0:7}: $v";; *) no "$tag compile.rail: ${v:-verifier produced no verdict}";; esac
+    # Both signals, captured separately: the verifier's exit status AND its
+    # verdict line. A verifier that prints ok and then dies (exit 139) is not
+    # a pass; neither is one that exits 0 without saying ok.
+    RAIL_ARENA_MB=2000 ./rail_native --out-prefix "$tmp/verify" run tools/attest/verify.rail \
+          "$tmp/compile.rail" "$idx/compile.rail.attestation.json" "$PUB" >"$tmp/verify.log" 2>&1; vrc=$?
+    v=$(grep -E '^(ok|BAD)' "$tmp/verify.log" | tail -1)
+    if [ "$vrc" = 0 ] && [ "${v#ok}" != "$v" ]; then ok "$tag compile.rail @ ${commit:0:7}: $v (exit 0)"
+    else no "$tag compile.rail: exit $vrc, verdict '${v:-none}'"; fi
   fi
 fi
 
 echo "== 6. The verifier binds the file to the signature (rejects a replacement artifact) =="
 if tools/attest/verify_selftest.sh "$PUB" >"$tmp/selftest.log" 2>&1; then ok "positive and replacement-artifact controls behave (tools/attest/verify_selftest.sh)"
 else no "verify_selftest failed:"; sed 's/^/     /' "$tmp/selftest.log"; fi
+
+echo "== 7. This script fails on a crashing test process and on a verifier that says ok then dies =="
+if tools/verify/check_selftest.sh >"$tmp/check_selftest.log" 2>&1; then ok "umbrella negative controls behave (tools/verify/check_selftest.sh)"
+else no "check_selftest failed:"; sed 's/^/     /' "$tmp/check_selftest.log"; fi
 
 echo
 echo "passed: $pass   failed: $fail"

--- a/tools/verify/check_selftest.sh
+++ b/tools/verify/check_selftest.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# tools/verify/check_selftest.sh: the umbrella script's own negative controls.
+#
+# Builds a throwaway fixture repo around a COPY of tools/verify/check.sh with a
+# stub rail_native, and asserts the umbrella says NO when:
+#   A. the test process exits 139 without printing anything (found 2026-09-06:
+#      the old script inferred success from the absence of the word FAIL);
+#   B. the release verifier prints `ok` and then exits 139 (found 2026-09-07:
+#      the verdict line was read through a pipe and the exit status lost).
+# Positive control C: a stub that behaves (N/N + exit 0, ok + exit 0) passes
+# sections 2 and 5, so the NOs above are not just a broken fixture.
+#
+# Usage: tools/verify/check_selftest.sh        exit 0 iff all three outcomes hold
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 2
+fx=$(mktemp -d /tmp/check_selftest_XXXXXX); trap 'rm -rf "$fx"' EXIT
+
+# Fixture: enough tree for sections 3, 4, 5, 6 to run, with 6 and 7 stubbed to
+# pass so the verdict under test is isolated to the stubbed rail_native.
+mkdir -p "$fx/tools/verify" "$fx/tools/attest" "$fx/tools/deploy" "$fx/grammar" "$fx/docs" "$fx/releases/v0.0.1"
+cp tools/verify/check.sh "$fx/tools/verify/check.sh"
+: > "$fx/grammar/rail.ebnf"; : > "$fx/docs/STATUS.md"; : > "$fx/tools/attest/verify.rail"; : > "$fx/tools/deploy/gen_status.rail"
+printf '#!/bin/bash\nexit 0\n' > "$fx/tools/attest/verify_selftest.sh"
+printf '#!/bin/bash\nexit 0\n' > "$fx/tools/verify/check_selftest.sh"
+chmod +x "$fx/tools/attest/verify_selftest.sh" "$fx/tools/verify/check_selftest.sh"
+: > "$fx/releases/v0.0.1/compile.rail.attestation.json"
+printf 'stub pubkey\n' > "$fx/pub.pem"
+git -C "$fx" init -q && git -C "$fx" -c user.name=fx -c user.email=fx@fx add -A \
+  && git -C "$fx" -c user.name=fx -c user.email=fx@fx commit -q -m fixture
+commit=$(git -C "$fx" rev-parse HEAD)
+printf '{"tag":"v0.0.1","git":{"commit":"%s"}}\n' "$commit" > "$fx/releases/v0.0.1/index.json"
+git -C "$fx" -c user.name=fx -c user.email=fx@fx add -A && git -C "$fx" -c user.name=fx -c user.email=fx@fx commit -q -m index
+
+# stub <test_exit> <test_output> <verifier_exit> <verifier_output>
+stub() {
+  cat > "$fx/rail_native" <<STUB
+#!/bin/bash
+case "\$1" in
+  quick|test) printf '%s\n' '$2'; exit $1;;
+  --out-prefix) shift 2; [ "\$1" = run ] && case "\$2" in *verify.rail) printf '%s\n' '$4'; exit $3;; esac; exit 0;;
+esac
+exit 0
+STUB
+  chmod +x "$fx/rail_native"
+}
+run() { (cd "$fx" && RAIL_WITNESS_PUB="$fx/pub.pem" bash tools/verify/check.sh --quick 2>&1); }
+fail=0
+expect() {  # <label> <want: 0|nonzero> <got>
+  if { [ "$2" = 0 ] && [ "$3" = 0 ]; } || { [ "$2" = nonzero ] && [ "$3" != 0 ]; }; then printf '  ok  %s (exit %s)\n' "$1" "$3"
+  else printf '  NO  %s (exit %s, wanted %s)\n' "$1" "$3" "$2"; fail=1; fi
+}
+
+stub 0 "15/15 quick tests passed" 0 "ok  artifact=compile.rail  pulse_id=1  pk_fp=stub"
+out=$(run); rc=$?; expect "C. well-behaved stub passes the umbrella" 0 $rc
+[ $rc = 0 ] || printf '%s\n' "$out" | sed 's/^/     /'
+
+stub 139 "" 0 "ok  artifact=compile.rail  pulse_id=1  pk_fp=stub"
+out=$(run); rc=$?; expect "A. test process exit 139, no output: umbrella fails" nonzero $rc
+printf '%s\n' "$out" | grep -q 'quick suite: exit 139' || { echo "  NO  A. section 2 did not name exit 139"; fail=1; }
+
+stub 0 "15/15 quick tests passed" 139 "ok  artifact=compile.rail  pulse_id=1  pk_fp=stub"
+out=$(run); rc=$?; expect "B. verifier prints ok then exits 139: umbrella fails" nonzero $rc
+printf '%s\n' "$out" | grep -q "compile.rail: exit 139" || { echo "  NO  B. section 5 did not name exit 139"; fail=1; }
+exit $fail


### PR DESCRIPTION
Follow-up to #63 from the same outside reviewer: `check.sh` section 5 read the Rail verifier's verdict through a pipe, so a verifier that printed `ok` and then exited 139 still passed the umbrella 5/5.

## What changed
- Section 5 runs the verifier to a log, captures its exit status, and requires exit 0 AND an `ok` verdict line. A crash after `ok`, or a silent exit 0, is NO and names the exit code.
- `verify_selftest.sh`: the Rail-verifier controls now require verdict and exit status to agree in both directions (`ok` + 0, `BAD` + nonzero).
- New `tools/verify/check_selftest.sh`: builds a fixture repo around a copy of `check.sh` with a stub `rail_native` and asserts three outcomes: a well-behaved stub passes (positive control), a test process exiting 139 fails, a verifier printing `ok` then exiting 139 fails. Run against the pre-fix `check.sh`, control B fails, which is the reviewer's reproduction.
- `check.sh` section 7 runs that selftest, so the umbrella carries its own negative controls.

## Verified
- `tools/verify/check_selftest.sh`: 3/3. `tools/attest/verify_selftest.sh`: 4/4.
- `tools/verify/check.sh --quick` on this branch: 6 of 6 run sections ok, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N21mSePADJbvTbB8MuwveT